### PR TITLE
3.1.0 changes

### DIFF
--- a/build/iw4x.vcxproj
+++ b/build/iw4x.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -310,6 +310,7 @@ tools\premake5 generate-buildinfo</Command>
     <ClInclude Include="..\src\Components\Modules\Weapon.hpp" />
     <ClInclude Include="..\src\Components\Modules\Window.hpp" />
     <ClInclude Include="..\src\Components\Modules\ZoneBuilder.hpp" />
+    <ClInclude Include="..\src\Components\Modules\SPLoadscreens.hpp" />
     <ClInclude Include="..\src\Components\Modules\Zones.hpp" />
     <ClInclude Include="..\src\Game\BothGames.hpp" />
     <ClInclude Include="..\src\Game\Client.hpp" />
@@ -505,6 +506,7 @@ tools\premake5 generate-buildinfo</Command>
     <ClCompile Include="..\src\Components\Modules\Weapon.cpp" />
     <ClCompile Include="..\src\Components\Modules\Window.cpp" />
     <ClCompile Include="..\src\Components\Modules\ZoneBuilder.cpp" />
+    <ClCompile Include="..\src\Components\Modules\SPLoadscreens.cpp" />
     <ClCompile Include="..\src\Components\Modules\Zones.cpp" />
     <ClCompile Include="..\src\DllMain.cpp" />
     <ClCompile Include="..\src\Game\BothGames.cpp" />

--- a/src/Components/Loader.cpp
+++ b/src/Components/Loader.cpp
@@ -72,6 +72,8 @@
 #include "Modules/Weapon.hpp"
 #include "Modules/Window.hpp"
 #include "Modules/Sound.hpp"
+#include "Modules/SPLoadscreens.hpp"
+
 
 #include "Modules/BotLib/lPrecomp.hpp"
 
@@ -109,10 +111,13 @@ namespace Components
 		// High priority
 		Register(new Singleton());
 
+		FileSystem::CleanupZw3Files();
+
 		Register(new Auth());
 		Register(new Command());
 		Register(new Dvar());
 		Register(new Exception()); // Install our exception handler as early as possible to get better debug dumps from startup crashes
+
 		Register(new MemoryGuard()); // Hook Sys_OutOfMemError early so startup OOMs are captured
 		Register(new MemoryTuning()); // Must run before engine registers r_picmip_* dvars
 		Register(new IPCPipe());
@@ -181,6 +186,7 @@ namespace Components
 		Register(new Session());
 		Register(new SlowMotion());
 		Register(new Sound());
+		Register(new SPLoadscreens());
 		Register(new StartupMessages());
 		Register(new Stats());
 		Register(new StringTable());

--- a/src/Components/Loader.cpp
+++ b/src/Components/Loader.cpp
@@ -73,6 +73,8 @@
 
 #include "Modules/BotLib/lPrecomp.hpp"
 
+#include <Utils/Leaderboard.hpp>
+
 namespace Components
 {
 	bool Loader::Pregame = true;
@@ -197,6 +199,8 @@ namespace Components
 		Register(new BotLib::lPrecomp());
 
 		//Register(new Debugger::DebugSetup());
+
+		Register(new Leaderboard());
 
 		Pregame = false;
 

--- a/src/Components/Modules/Branding.cpp
+++ b/src/Components/Modules/Branding.cpp
@@ -9,9 +9,9 @@ namespace Components
 	Dvar::Var Branding::CGDrawVersionY;
 
 #ifdef _DEBUG
-	constexpr auto* BUILD_TYPE = "Zombie Warfare 3 (Debug)";
+	constexpr auto* BUILD_TYPE = "Call of Duty: Zombie Warfare 3 (Debug)";
 #else
-	constexpr auto* BUILD_TYPE = "Zombie Warfare 3";
+	constexpr auto* BUILD_TYPE = "Call of Duty: Zombie Warfare 3";
 #endif
 
 	void Branding::CG_DrawVersion()
@@ -136,19 +136,19 @@ namespace Components
 		// Console title
 		if (ZoneBuilder::IsEnabled())
 		{
-			Utils::Hook::Set<const char*>(0x4289E8, "Zombie Warfare 3 [ZoneBuilder]");
+			Utils::Hook::Set<const char*>(0x4289E8, "Call of Duty: Zombie Warfare 3 [ZoneBuilder]");
 		}
 		else if (Dedicated::IsEnabled())
 		{
 #ifdef EXPERIMENTAL_BUILD
-			Utils::Hook::Set<const char*>(0x4289E8, "Zombie Warfare 3 [Dedicated]");
+			Utils::Hook::Set<const char*>(0x4289E8, "Call of Duty: Zombie Warfare 3 [Dedicated]");
 #else
-			Utils::Hook::Set<const char*>(0x4289E8, "Zombie Warfare 3 [Dedicated]");
+			Utils::Hook::Set<const char*>(0x4289E8, "Call of Duty: Zombie Warfare 3 [Dedicated]");
 #endif
 		}
 		else
 		{
-			Utils::Hook::Set<const char*>(0x4289E8, "Zombie Warfare 3 [Console]");
+			Utils::Hook::Set<const char*>(0x4289E8, "Call of Duty: Zombie Warfare 3 [Console]");
 		}
 	}
 }

--- a/src/Components/Modules/Console.cpp
+++ b/src/Components/Modules/Console.cpp
@@ -98,9 +98,9 @@ namespace Components
 		else if (IsWindow(GetWindow()) != FALSE)
 		{
 #ifdef EXPERIMENTAL_BUILD
-			SetWindowTextA(GetWindow(), Utils::String::Format("Zombie Warfare 3: {}", hostname));
+			SetWindowTextA(GetWindow(), Utils::String::Format("Call of Duty: Zombie Warfare 3 - {}", hostname));
 #else
-			SetWindowTextA(GetWindow(), Utils::String::Format("Zombie Warfare 3: {}", hostname));
+			SetWindowTextA(GetWindow(), Utils::String::Format("Call of Duty: Zombie Warfare 3 - {}", hostname));
 #endif
 		}
 	}
@@ -861,9 +861,9 @@ namespace Components
 
 		// Console '%s: %s> ' string
 #ifdef EXPERIMENTAL_BUILD
-		Utils::Hook::Set<const char*>(0x5A44B4, "Zombie Warfare 3> ");
+		Utils::Hook::Set<const char*>(0x5A44B4, "Call of Duty: Zombie Warfare 3> ");
 #else
-		Utils::Hook::Set<const char*>(0x5A44B4, "Zombie Warfare 3> ");
+		Utils::Hook::Set<const char*>(0x5A44B4, "Call of Duty: Zombie Warfare 3> ");
 #endif
 
 		// Patch console color

--- a/src/Components/Modules/Exception.cpp
+++ b/src/Components/Modules/Exception.cpp
@@ -60,7 +60,7 @@ namespace Components
 	std::wstring Exception::GetErrorMessage(const std::string& error)
 	{
 		//const auto clientVersion = (*Game::shortversion)->current.string;
-		const std::string clientVersion = "3.0.2";
+		const std::string clientVersion = "3.1.0";
 		const auto osVersion = Utils::IsWineEnvironment() ? "Wine" : Utils::GetWindowsVersion();
 		const auto launchParams = Utils::String::Convert(Utils::GetLaunchParameters());
 

--- a/src/Components/Modules/News.cpp
+++ b/src/Components/Modules/News.cpp
@@ -4,7 +4,7 @@
 #include "rapidjson/document.h"
 #include "version.h"
 
-#define NEWS_MOTD_DEFAULT "Welcome to Zombie Warfare 3!"
+#define NEWS_MOTD_DEFAULT "Welcome to Call of Duty: Zombie Warfare 3!"
 
 /*
   MOTD, Changelog and popup messages are fetched as JSON using Cache::GetFile.

--- a/src/Components/Modules/Party.cpp
+++ b/src/Components/Modules/Party.cpp
@@ -668,99 +668,124 @@ namespace Components
 
 		UIScript::Add("LoadSave", []([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
 			{
-				// We don't want to show the autosave popup if we're not the host
-				if (!Dvar::Var("party_host").get<bool>())
+				// The autosave popup should only be shown when party_host is true. If the
+				// dvar hasn't been set yet, we poll for a short time to allow the menu to
+				// initialize it.
+				auto doLoadSave = []()
 				{
-					return;
-				}
+					std::string path = (*Game::fs_basepath)->current.string + "\\userraw\\scriptdata\\autosave"s;
 
-				std::string path = (*Game::fs_basepath)->current.string + "\\userraw\\scriptdata\\autosave"s;
-
-				std::ifstream f(path);
-				if (!f.is_open())
-				{
-					return;
-				}
-
-				{
-					struct _stat64 st {};
-					if (_stat64(path.c_str(), &st) == 0)
-					{
-						tm t{};
-						localtime_s(&t, &st.st_mtime);
-
-						char formatted[128];
-						strftime(formatted, sizeof(formatted), "%d %b %Y  %H:%M", &t);
-
-						if (!Game::Dvar_FindVar("autosave_date"))
-						{
-							Game::Dvar_RegisterString("autosave_date", "", 0, "");
-						}
-
-						Game::Dvar_SetString(Game::Dvar_FindVar("autosave_date"), formatted);
-					}
-					else
+					std::ifstream f(path);
+					if (!f.is_open())
 					{
 						return;
 					}
-				}
 
-				std::string fdata((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
-				f.close();
+					{
+						struct _stat64 st {};
+						if (_stat64(path.c_str(), &st) == 0)
+						{
+							tm t{};
+							localtime_s(&t, &st.st_mtime);
 
-				std::string read = fdata;
-				int key = 16;
+							char formatted[128];
+							strftime(formatted, sizeof(formatted), "%d %b %Y  %H:%M", &t);
 
-				std::string data = decryptString(read, key);
+							if (!Game::Dvar_FindVar("autosave_date"))
+							{
+								Game::Dvar_RegisterString("autosave_date", "", 0, "");
+							}
 
-				std::unordered_map<std::string, std::string> parsed;
-				size_t start = 0;
+							Game::Dvar_SetString(Game::Dvar_FindVar("autosave_date"), formatted);
+						}
+						else
+						{
+							return;
+						}
+					}
 
-				while (true)
-				{
-					size_t s = data.find(';', start);
-					if (s == std::string::npos) break;
+					std::string fdata((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+					f.close();
 
-					std::string t = data.substr(start, s - start);
-					start = s + 1;
+					std::string read = fdata;
+					int key = 16;
 
-					size_t c = t.find(':');
-					if (c == std::string::npos) continue;
+					std::string data = decryptString(read, key);
 
-					std::string k = t.substr(0, c);
-					std::string v = t.substr(c + 1);
+					std::unordered_map<std::string, std::string> parsed;
+					size_t start = 0;
 
-					auto trim = [](std::string& x)
+					while (true)
+					{
+						size_t s = data.find(';', start);
+						if (s == std::string::npos) break;
+
+						std::string t = data.substr(start, s - start);
+						start = s + 1;
+
+						size_t c = t.find(':');
+						if (c == std::string::npos) continue;
+
+						std::string k = t.substr(0, c);
+						std::string v = t.substr(c + 1);
+
+						auto trim = [](std::string& x)
 						{
 							while (!x.empty() && strchr(" \n\r\t", x.back())) x.pop_back();
 							while (!x.empty() && strchr(" \n\r\t", x.front())) x.erase(x.begin());
 						};
 
-					trim(k);
-					trim(v);
+						trim(k);
+						trim(v);
 
-					parsed[k] = v;
-				}
-
-				if (!parsed.count("map"))
-				{
-					return;
-				}
-
-				for (const auto& p : parsed)
-				{
-					std::string dvarName = "autosave_" + p.first;
-
-					auto var = Game::Dvar_FindVar(dvarName.c_str());
-					if (!var)
-					{
-						var = Game::Dvar_RegisterString(dvarName.c_str(), "", 0, "");
+						parsed[k] = v;
 					}
 
-					Game::Dvar_SetString(var, p.second.c_str());
-				}
+					if (!parsed.count("map"))
+					{
+						return;
+					}
 
-				Command::Execute("openmenu popup_autosave");
+					for (const auto& p : parsed)
+					{
+						std::string dvarName = "autosave_" + p.first;
+
+						auto var = Game::Dvar_FindVar(dvarName.c_str());
+						if (!var)
+						{
+							var = Game::Dvar_RegisterString(dvarName.c_str(), "", 0, "");
+						}
+
+						Game::Dvar_SetString(var, p.second.c_str());
+					}
+
+					Command::Execute("openmenu popup_autosave");
+				};
+
+				// If party_host is already true, run immediately. Otherwise poll for it for up to 2s.
+				auto* partyHostVarNow = Game::Dvar_FindVar("party_host");
+				if (partyHostVarNow && Dvar::Var("party_host").get<bool>())
+				{
+					doLoadSave();
+				}
+				else
+				{
+					const auto startMs = Game::Sys_Milliseconds();
+					Scheduler::Schedule([startMs, doLoadSave]() mutable -> bool
+					{
+						auto* ph = Game::Dvar_FindVar("party_host");
+						if (ph && Dvar::Var("party_host").get<bool>())
+						{
+							doLoadSave();
+							return true;
+						}
+						if ((Game::Sys_Milliseconds() - startMs) > 2000)
+						{
+							return true;
+						}
+						return false;
+					}, Scheduler::Pipeline::MAIN, 50ms);
+				}
 			});
 
 

--- a/src/Components/Modules/Party.cpp
+++ b/src/Components/Modules/Party.cpp
@@ -668,10 +668,12 @@ namespace Components
 
 		UIScript::Add("LoadSave", []([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
 			{
-				/*std::string guid = Utils::String::VA("%016llX", Steam::SteamUser()->GetSteamID().bits);
-				std::transform(guid.begin(), guid.end(), guid.begin(), ::tolower);
+				// We don't want to show the autosave popup if we're not the host
+				if (!Dvar::Var("party_host").get<bool>())
+				{
+					return;
+				}
 
-				std::string path = (*Game::fs_basepath)->current.string + "\\userraw\\scriptdata\\autosave_"s + guid;*/
 				std::string path = (*Game::fs_basepath)->current.string + "\\userraw\\scriptdata\\autosave"s;
 
 				std::ifstream f(path);

--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -424,7 +424,7 @@ namespace Components
 		Utils::Hook::Set<const char*>(0x6431D1, BASEGAME);
 
 		// window title
-		Utils::Hook::Set<const char*>(0x5076A0, "Zombie Warfare 3");
+		Utils::Hook::Set<const char*>(0x5076A0, "Call of Duty: Zombie Warfare 3");
 
 		// sv_hostname
 		Utils::Hook::Set<const char*>(0x4D378B, "ZW3Host");

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -1,0 +1,132 @@
+#include "SPLoadscreens.hpp"
+#include "AssetHandler.hpp"
+#include "FileSystem.hpp"
+#include "Materials.hpp"
+#include "STDInclude.hpp"
+
+namespace Components {
+	SPLoadscreens::SPLoadscreens()
+	{
+		auto getPreviewImage = [](const std::string& materialName) -> Game::GfxImage*
+		{
+			std::string mapname = "";
+			if (Utils::String::StartsWith(materialName, "loadscreen_"))
+			{
+				mapname = materialName.substr(11);
+			}
+			else
+			{
+				// Fallback to current map dvar if it's a generic loadscreen material
+				Game::dvar_t* ui_mapname = Game::Dvar_FindVar("ui_mapname");
+				if (ui_mapname && ui_mapname->current.string)
+				{
+					mapname = ui_mapname->current.string;
+				}
+			}
+
+			if (mapname.empty()) return nullptr;
+
+			std::vector<std::string> variants = { "preview_" + mapname };
+			
+			// Handle potential underscores
+			if (mapname.find('_') != std::string::npos)
+			{
+				std::string simpleName = mapname;
+				Utils::String::Replace(simpleName, "_", "");
+				variants.push_back("preview_" + simpleName);
+			}
+
+			for (const auto& variant : variants)
+			{
+				if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
+				{
+					Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
+					if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
+					{
+						imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
+						AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
+					}
+					return imageHeader.image;
+				}
+			}
+
+			return nullptr;
+		};
+
+		auto patchMaterial = [getPreviewImage](Game::Material* material, const std::string& name)
+		{
+			if (!material) return;
+
+			Game::GfxImage* image = getPreviewImage(name);
+			if (image && !strstr(image->name, "default"))
+			{
+				for (int i = 0; i < material->textureCount; ++i)
+				{
+					if (material->textureTable[i].u.image && strstr(material->textureTable[i].u.image->name, "default"))
+					{
+						material->textureTable[i].u.image = image;
+					}
+				}
+			}
+		};
+
+		// Passive hooks for materials
+		AssetHandler::OnFind(Game::ASSET_TYPE_MATERIAL, [getPreviewImage](Game::XAssetType type, const std::string& name) -> Game::XAssetHeader
+		{
+			if (Utils::String::Contains(name, "loadscreen") || name == "loading_image")
+			{
+				Game::GfxImage* image = getPreviewImage(name);
+				if (image && !strstr(image->name, "default"))
+				{
+					Game::Material* material = Materials::Create(name, image);
+					return { material };
+				}
+			}
+
+			return { nullptr };
+		});
+
+		AssetHandler::OnLoad([getPreviewImage](Game::XAssetType type, Game::XAssetHeader asset, const std::string& name, bool*)
+		{
+			if (type == Game::ASSET_TYPE_MATERIAL && (Utils::String::Contains(name, "loadscreen") || name == "loading_image"))
+			{
+				Game::GfxImage* image = getPreviewImage(name);
+				if (image && !strstr(image->name, "default"))
+				{
+					for (int i = 0; i < asset.material->textureCount; ++i)
+					{
+						if (asset.material->textureTable[i].u.image && strstr(asset.material->textureTable[i].u.image->name, "default"))
+						{
+							asset.material->textureTable[i].u.image = image;
+						}
+					}
+				}
+			}
+		});
+
+		// Active monitoring for the connect menu
+		Scheduler::Loop([getPreviewImage, patchMaterial]()
+		{
+			Game::menuDef_t* connectMenu = Game::Menus_FindByName(Game::uiContext, "connect");
+			if (connectMenu && Game::Menu_IsVisible(Game::uiContext, connectMenu))
+			{
+				// Patch the menu's own background
+				patchMaterial(connectMenu->window.background, "level_loadscreen");
+
+				// Patch all items in the connect menu
+				for (int i = 0; i < connectMenu->itemCount; ++i)
+				{
+					Game::itemDef_s* item = connectMenu->items[i];
+					if (item)
+					{
+						patchMaterial(item->window.background, item->window.name ? item->window.name : "level_loadscreen");
+					}
+				}
+			}
+		}, Scheduler::Pipeline::MAIN);
+	}
+
+
+
+SPLoadscreens::~SPLoadscreens() {}
+} // namespace Components

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -8,125 +8,149 @@ namespace Components {
 	SPLoadscreens::SPLoadscreens()
 	{
 		auto getPreviewImage = [](const std::string& materialName) -> Game::GfxImage*
-		{
-			std::string mapname = "";
-			if (Utils::String::StartsWith(materialName, "loadscreen_"))
 			{
-				mapname = materialName.substr(11);
-			}
-			else
-			{
-				// Fallback to current map dvar if it's a generic loadscreen material
-				Game::dvar_t* ui_mapname = Game::Dvar_FindVar("ui_mapname");
-				if (ui_mapname && ui_mapname->current.string)
+				std::string mapname = "";
+				if (Utils::String::StartsWith(materialName, "loadscreen_"))
 				{
-					mapname = ui_mapname->current.string;
+					mapname = materialName.substr(11);
 				}
-			}
-
-			if (mapname.empty()) return nullptr;
-
-			std::vector<std::string> variants = { "preview_" + mapname };
-			
-			// Handle potential underscores
-			if (mapname.find('_') != std::string::npos)
-			{
-				std::string simpleName = mapname;
-				Utils::String::Replace(simpleName, "_", "");
-				variants.push_back("preview_" + simpleName);
-			}
-
-			for (const auto& variant : variants)
-			{
-				if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
+				else
 				{
-					Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
-					if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
+					// Fallback to current map dvar if it's a generic loadscreen material
+					Game::dvar_t* ui_mapname = Game::Dvar_FindVar("ui_mapname");
+					if (ui_mapname && ui_mapname->current.string)
 					{
-						imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
-						AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
-					}
-					return imageHeader.image;
-				}
-			}
-
-			return nullptr;
-		};
-
-		auto patchMaterial = [getPreviewImage](Game::Material* material, const std::string& name)
-		{
-			if (!material) return;
-
-			Game::GfxImage* image = getPreviewImage(name);
-			if (image && !strstr(image->name, "default"))
-			{
-				for (int i = 0; i < material->textureCount; ++i)
-				{
-					if (material->textureTable[i].u.image && strstr(material->textureTable[i].u.image->name, "default"))
-					{
-						material->textureTable[i].u.image = image;
+						mapname = ui_mapname->current.string;
 					}
 				}
-			}
-		};
 
-		// Passive hooks for materials
-		AssetHandler::OnFind(Game::ASSET_TYPE_MATERIAL, [getPreviewImage](Game::XAssetType type, const std::string& name) -> Game::XAssetHeader
-		{
-			if (Utils::String::Contains(name, "loadscreen") || name == "loading_image")
-			{
-				Game::GfxImage* image = getPreviewImage(name);
-				if (image && !strstr(image->name, "default"))
+				if (mapname.empty()) return nullptr;
+
+				// If the map name starts with "mp_", we skip it entirely
+				if (Utils::String::StartsWith(mapname, "mp_"))
 				{
-					Game::Material* material = Materials::Create(name, image);
-					return { material };
+					return nullptr;
 				}
-			}
 
-			return { nullptr };
-		});
+				std::vector<std::string> variants = { "preview_" + mapname };
 
-		AssetHandler::OnLoad([getPreviewImage](Game::XAssetType type, Game::XAssetHeader asset, const std::string& name, bool*)
-		{
-			if (type == Game::ASSET_TYPE_MATERIAL && (Utils::String::Contains(name, "loadscreen") || name == "loading_image"))
-			{
-				Game::GfxImage* image = getPreviewImage(name);
-				if (image && !strstr(image->name, "default"))
+				// Handle potential underscores
+				if (mapname.find('_') != std::string::npos)
 				{
-					for (int i = 0; i < asset.material->textureCount; ++i)
+					std::string simpleName = mapname;
+					Utils::String::Replace(simpleName, "_", "");
+					variants.push_back("preview_" + simpleName);
+				}
+
+				for (const auto& variant : variants)
+				{
+					if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
 					{
-						if (asset.material->textureTable[i].u.image && strstr(asset.material->textureTable[i].u.image->name, "default"))
+						Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
+						if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
 						{
-							asset.material->textureTable[i].u.image = image;
+							imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
+							AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
+						}
+						return imageHeader.image;
+					}
+				}
+
+				return nullptr;
+			};
+
+		auto patchMaterial = [getPreviewImage](Game::Material* material, const std::string& name, bool isElementExplicit)
+			{
+				if (!material) return;
+
+				Game::GfxImage* image = getPreviewImage(name);
+				if (image && !strstr(image->name, "default"))
+				{
+					for (int i = 0; i < material->textureCount; ++i)
+					{
+						if (material->textureTable[i].u.image)
+						{
+							bool isDefault = strstr(material->textureTable[i].u.image->name, "default") != nullptr;
+							bool isOldPreview = strstr(material->textureTable[i].u.image->name, "preview_") != nullptr &&
+								strstr(material->textureTable[i].u.image->name, image->name) == nullptr;
+							if (isDefault || (isOldPreview && isElementExplicit))
+							{
+								material->textureTable[i].u.image = image;
+							}
 						}
 					}
 				}
-			}
-		});
+			};
+
+		// Passive hooks for materials
+		AssetHandler::OnFind(Game::ASSET_TYPE_MATERIAL, [getPreviewImage](Game::XAssetType type, const std::string& name) -> Game::XAssetHeader
+			{
+				if (Utils::String::Contains(name, "loadscreen") || name == "loading_image")
+				{
+					Game::GfxImage* image = getPreviewImage(name);
+					if (image && !strstr(image->name, "default"))
+					{
+						Game::Material* material = Materials::Create(name, image);
+						return { material };
+					}
+				}
+
+				return { nullptr };
+			});
+
+		AssetHandler::OnLoad([getPreviewImage](Game::XAssetType type, Game::XAssetHeader asset, const std::string& name, bool*)
+			{
+				if (type == Game::ASSET_TYPE_MATERIAL && (Utils::String::Contains(name, "loadscreen") || name == "loading_image"))
+				{
+					Game::GfxImage* image = getPreviewImage(name);
+					if (image && !strstr(image->name, "default"))
+					{
+						for (int i = 0; i < asset.material->textureCount; ++i)
+						{
+							if (asset.material->textureTable[i].u.image && strstr(asset.material->textureTable[i].u.image->name, "default"))
+							{
+								asset.material->textureTable[i].u.image = image;
+							}
+						}
+					}
+				}
+			});
 
 		// Active monitoring for the connect menu
 		Scheduler::Loop([getPreviewImage, patchMaterial]()
-		{
-			Game::menuDef_t* connectMenu = Game::Menus_FindByName(Game::uiContext, "connect");
-			if (connectMenu && Game::Menu_IsVisible(Game::uiContext, connectMenu))
 			{
-				// Patch the menu's own background
-				patchMaterial(connectMenu->window.background, "level_loadscreen");
-
-				// Patch all items in the connect menu
-				for (int i = 0; i < connectMenu->itemCount; ++i)
+				Game::menuDef_t* connectMenu = Game::Menus_FindByName(Game::uiContext, "connect");
+				if (connectMenu && Game::Menu_IsVisible(Game::uiContext, connectMenu))
 				{
-					Game::itemDef_s* item = connectMenu->items[i];
-					if (item)
+					// Patch the menu's own background
+					patchMaterial(connectMenu->window.background, "level_loadscreen", true);
+
+					// Patch items in the connect menu
+					for (int i = 0; i < connectMenu->itemCount; ++i)
 					{
-						patchMaterial(item->window.background, item->window.name ? item->window.name : "level_loadscreen");
+						Game::itemDef_s* item = connectMenu->items[i];
+						if (item)
+						{
+							bool isExplicitTarget = false;
+							if (item->window.name)
+							{
+								std::string winName = item->window.name;
+								if (Utils::String::Contains(winName, "loadscreen") || Utils::String::Contains(winName, "preview"))
+								{
+									isExplicitTarget = true;
+								}
+							}
+							else
+							{
+								isExplicitTarget = true;
+							}
+
+							patchMaterial(item->window.background, item->window.name ? item->window.name : "level_loadscreen", isExplicitTarget);
+						}
 					}
 				}
-			}
-		}, Scheduler::Pipeline::MAIN);
+			}, Scheduler::Pipeline::MAIN);
 	}
 
-
-
-SPLoadscreens::~SPLoadscreens() {}
+	SPLoadscreens::~SPLoadscreens() {}
 } // namespace Components

--- a/src/Components/Modules/SPLoadscreens.hpp
+++ b/src/Components/Modules/SPLoadscreens.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace Components
+{
+	class SPLoadscreens : public Component
+	{
+	public:
+		SPLoadscreens();
+		~SPLoadscreens();
+	};
+}

--- a/src/Components/Modules/Singleton.cpp
+++ b/src/Components/Modules/Singleton.cpp
@@ -27,9 +27,9 @@ namespace Components
 		if (Flags::HasFlag("version"))
 		{
 #ifdef EXPERIMENTAL_BUILD
-			printf("%s", "Zombie Warfare 3 (built " __DATE__ " " __TIME__ ")\n");
+			printf("%s", "Call of Duty: Zombie Warfare 3 (built " __DATE__ " " __TIME__ ")\n");
 #else
-			printf("%s", "Zombie Warfare 3 (built " __DATE__ " " __TIME__ ")\n");
+			printf("%s", "Call of Duty: Zombie Warfare 3 (built " __DATE__ " " __TIME__ ")\n");
 #endif
 
 			ExitProcess(EXIT_SUCCESS);

--- a/src/Resource.rc
+++ b/src/Resource.rc
@@ -62,7 +62,7 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "CompanyName", "Zombie Warfare 3"
+            VALUE "CompanyName", "Call of Duty: Zombie Warfare 3"
 #ifdef _DEBUG
             VALUE "FileDescription", "ZW3 client modification (Debug)"
 #else
@@ -70,10 +70,10 @@ BEGIN
 #endif
             VALUE "FileVersion", REVISION_STR
             VALUE "InternalName", "ZW3"
-            VALUE "LegalCopyright", "Copyright 2025 The Zombie Warfare Team. All rights reserved."
+            VALUE "LegalCopyright", "Copyright 2025-2026 The Zombie Warfare Team. All rights reserved."
             VALUE "OriginalFilename", "zw3.dll"
-            VALUE "ProductName", "Zombie Warfare 3"
-            VALUE "ProductVersion", "3.0.2"
+            VALUE "ProductName", "Call of Duty: Zombie Warfare 3"
+            VALUE "ProductVersion", "3.1.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/Steam/Proxy.cpp
+++ b/src/Steam/Proxy.cpp
@@ -156,7 +156,7 @@ namespace Steam
 		gameID.type = 1; // k_EGameIDTypeGameMod
 		gameID.appID = Proxy::AppId & 0xFFFFFF;
 
-		const char* modId = "Zombie Warfare 3";
+		const char* modId = "Call of Duty: Zombie Warfare 3";
 		gameID.modID = *reinterpret_cast<const unsigned int*>(modId) | 0x80000000;
 
 		Interface clientUtils(Proxy::ClientEngine->GetIClientUtils(Proxy::SteamPipe));

--- a/src/Steam/Steam.cpp
+++ b/src/Steam/Steam.cpp
@@ -129,7 +129,7 @@ namespace Steam
 				}
 				else
 				{
-					Proxy::SetMod("Zombie Warfare 3");
+					Proxy::SetMod("Call of Duty: Zombie Warfare 3");
 					Proxy::RunGame();
 				}
 			}

--- a/src/Utils/Cache.hpp
+++ b/src/Utils/Cache.hpp
@@ -8,7 +8,7 @@ namespace Utils
 		static const char* Urls[];
 
 		static std::string GetUrl(const std::string& url, const std::string& path);
-		static std::string GetFile(const std::string& path, int timeout = 5000, const std::string& useragent = "Zombie Warfare 3");
+		static std::string GetFile(const std::string& path, int timeout = 5000, const std::string& useragent = "Call of Duty: Zombie Warfare 3");
 
 	private:
 		static std::mutex CacheMutex;

--- a/src/Utils/Hooking.hpp
+++ b/src/Utils/Hooking.hpp
@@ -67,6 +67,11 @@ namespace Utils
 		void* getAddress();
 		void quick();
 
+		template <typename T> T* get_original() const
+		{
+			return reinterpret_cast<T*>(this->original);
+		}
+
 		template <typename T> static std::function<T> Call(DWORD function)
 		{
 			return std::function<T>(reinterpret_cast<T*>(function));

--- a/src/Utils/Leaderboard.cpp
+++ b/src/Utils/Leaderboard.cpp
@@ -214,11 +214,15 @@ namespace Components
 	void Leaderboard::RefreshFirstPage([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
 	{
 		const auto mapName = GetCurrentMapName();
-		StartRefresh(mapName == CurrentMap ? CurrentOffset : 0);
+		if (CurrentOffset != 0 || Entries.empty() || mapName != CurrentMap)
+		{
+			StartRefresh(0);
+		}
 	}
 
 	void Leaderboard::PreviousPage([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
 	{
+		if (CurrentOffset <= 0) return;
 		StartRefresh(std::max(0, CurrentOffset - DefaultLimit));
 	}
 

--- a/src/Utils/Leaderboard.cpp
+++ b/src/Utils/Leaderboard.cpp
@@ -14,12 +14,17 @@
 namespace Components
 {
 	std::vector<Leaderboard::Entry> Leaderboard::Entries;
-	Dvar::Var Leaderboard::UILeaderboardStatus;
-	Dvar::Var Leaderboard::UILeaderboardFirst;
 	Dvar::Var Leaderboard::UILeaderboardMap;
 	Dvar::Var Leaderboard::UILeaderboardPage;
-	int Leaderboard::CurrentPage = DefaultPage;
+	Dvar::Var Leaderboard::UILeaderboardLoadingIndicator;
+	int Leaderboard::CurrentOffset = 0;
+	int Leaderboard::NextOffset = -1;
+int Leaderboard::TotalItems = -1;
 	bool Leaderboard::HasNextPage = false;
+	bool Leaderboard::Loading = false;
+	unsigned int Leaderboard::RequestSerial = 0;
+	int Leaderboard::LoadingFrame = 0;
+	std::string Leaderboard::CurrentMap;
 
 	const char* Leaderboard::GetApiKey()
 	{
@@ -38,7 +43,7 @@ namespace Components
 
 	static int GetJsonInt(const rapidjson::Value& object, const char* key, int fallback = 0)
 	{
-		if (!object.HasMember(key)) return fallback;
+		if (!object.HasMember(key) || object[key].IsNull()) return fallback;
 		if (object[key].IsInt()) return object[key].GetInt();
 		if (object[key].IsNumber()) return static_cast<int>(object[key].GetDouble());
 		return fallback;
@@ -46,7 +51,7 @@ namespace Components
 
 	static float GetJsonFloat(const rapidjson::Value& object, const char* key, float fallback = 0.0f)
 	{
-		if (!object.HasMember(key)) return fallback;
+		if (!object.HasMember(key) || object[key].IsNull()) return fallback;
 		if (object[key].IsNumber()) return static_cast<float>(object[key].GetDouble());
 		return fallback;
 	}
@@ -66,31 +71,23 @@ namespace Components
 		return Utils::String::VA("%02i:%02i", minutes, secs);
 	}
 
-	static std::string NormalizePlayerName(std::string player)
-	{
-		Utils::String::Trim(player);
-		std::transform(player.begin(), player.end(), player.begin(), [](const unsigned char c)
-			{
-				return static_cast<char>(std::tolower(c));
-			});
-
-		return player;
-	}
-
-	bool Leaderboard::IsBetterEntry(const Entry& candidate, const Entry& current)
-	{
-		if (candidate.round != current.round) return candidate.round > current.round;
-		if (candidate.score != current.score) return candidate.score > current.score;
-		if (candidate.kills != current.kills) return candidate.kills > current.kills;
-		if (candidate.downs != current.downs) return candidate.downs < current.downs;
-		if (candidate.revives != current.revives) return candidate.revives > current.revives;
-		if (candidate.exfiltrated != current.exfiltrated) return candidate.exfiltrated > current.exfiltrated;
-		return candidate.time < current.time;
-	}
-
 	void Leaderboard::UpdatePageDvar()
 	{
-		UILeaderboardPage.set(Utils::String::VA("Page %i%s", CurrentPage, HasNextPage ? "" : " (last)"));
+		const auto page = (CurrentOffset / DefaultLimit) + 1;
+		if (TotalItems >= 0)
+		{
+			const auto totalPages = std::max(1, (TotalItems + DefaultLimit - 1) / DefaultLimit);
+			UILeaderboardPage.set(Utils::String::VA("Page %i of %i", page, totalPages));
+			return;
+		}
+
+		if (!HasNextPage)
+		{
+			UILeaderboardPage.set(Utils::String::VA("Page %i of %i", page, page));
+			return;
+		}
+
+		UILeaderboardPage.set(Utils::String::VA("Page %i", page));
 	}
 
 	std::string Leaderboard::GetCurrentMapName()
@@ -138,115 +135,146 @@ namespace Components
 		return encoded;
 	}
 
-	void Leaderboard::Refresh([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
+	void Leaderboard::UpdateLoadingStatus()
 	{
-		Entries.clear();
-		UpdatePageDvar();
+		if (!Loading)
+		{
+			return;
+		}
 
+		constexpr const char* spinner[] = { "|", "/", "-", "\\" };
+		constexpr const char* dots[] = { ".", "..", "..." };
+		UILeaderboardLoadingIndicator.set(Utils::String::VA("%s Loading%s",
+			spinner[LoadingFrame % std::size(spinner)],
+			dots[LoadingFrame % std::size(dots)]));
+		LoadingFrame++;
+	}
+
+	void Leaderboard::StartRefresh(int offset)
+	{
 		const auto mapName = GetCurrentMapName();
 		UILeaderboardMap.set(mapName.empty() ? "Unknown" : mapName);
 
 		if (mapName.empty())
 		{
-			UILeaderboardStatus.set("^1Could not detect current map.");
-			UILeaderboardFirst.set("The mapname, sv_mapname, and ui_mapname dvars are empty.");
-			Toast::Show("cardicon_redhand", "^1Stats", "Could not detect the current map for stats lookup.", 5000);
-			return;
-		}
-
-		UILeaderboardStatus.set(Utils::String::VA("Loading stats for %s, page %i...", mapName.data(), CurrentPage));
-		UILeaderboardFirst.set("Waiting for stats API response...");
-
-		const auto url = std::format(
-			"https://stats.zw3.eu/matches/data?page={}&per_page={}&period={}&map={}",
-			CurrentPage,
-			DefaultPerPage,
-			DefaultPeriod,
-			UrlEncode(mapName));
-
-		Utils::WebIO::params headers;
-		headers["Content-Type"] = "application/json";
-		const auto reply = Utils::WebIO("zw3-map-stats", url).setTimeout(5000)->get(headers);
-
-		if (reply.empty())
-		{
-			UILeaderboardStatus.set("^1Could not load stats.");
-			UILeaderboardFirst.set(Utils::String::VA("No HTTP response for map %s, page %i.", mapName.data(), CurrentPage));
-			Toast::Show("cardicon_redhand", "^1Stats", "Could not get a response from the stats API.", 5000);
-			return;
-		}
-
-		ParseResponse(reply, mapName);
-	}
-
-	void Leaderboard::RefreshFirstPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info)
-	{
-		CurrentPage = DefaultPage;
-		Refresh(token, info);
-	}
-
-	void Leaderboard::PreviousPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info)
-	{
-		if (CurrentPage <= DefaultPage)
-		{
-			UILeaderboardStatus.set("^3Already on the first stats page.");
+			++RequestSerial;
+			Entries.clear();
+			Loading = false;
+			HasNextPage = false;
+			NextOffset = -1;
+			UILeaderboardLoadingIndicator.set("No map");
 			UpdatePageDvar();
+			Toast::Show("cardicon_redhand", "^1Leaderboard", "Could not detect the current map for leaderboard lookup.", 5000);
 			return;
 		}
 
-		--CurrentPage;
-		Refresh(token, info);
+		CurrentMap = mapName;
+		CurrentOffset = std::max(0, offset);
+		const auto requestId = ++RequestSerial;
+		Entries.clear();
+		HasNextPage = false;
+		NextOffset = -1;
+		UpdatePageDvar();
+
+		Loading = true;
+		LoadingFrame = 0;
+		UpdateLoadingStatus();
+
+		const auto url = CurrentOffset > 0
+			? std::format("https://stats.zw3.eu/leaderboard/best-rounds?limit={}&map={}&offset={}", DefaultLimit, UrlEncode(mapName), CurrentOffset)
+			: std::format("https://stats.zw3.eu/leaderboard/best-rounds?limit={}&map={}", DefaultLimit, UrlEncode(mapName));
+
+		Scheduler::Once([requestId, url]
+			{
+				Utils::WebIO::params headers;
+				headers["Content-Type"] = "application/json";
+				const auto reply = Utils::WebIO("zw3-best-rounds", url).setTimeout(5000)->get(headers);
+
+				Scheduler::Once([requestId, reply]
+					{
+						if (requestId != RequestSerial)
+						{
+							return;
+						}
+
+						Loading = false;
+						UILeaderboardLoadingIndicator.set("");
+
+						if (reply.empty())
+						{
+							UILeaderboardLoadingIndicator.set("Load failed");
+							Toast::Show("cardicon_redhand", "^1Leaderboard", "Could not get a response from the stats API.", 5000);
+							return;
+						}
+
+						ParseResponse(reply);
+					}, Scheduler::Pipeline::MAIN);
+			}, Scheduler::Pipeline::ASYNC);
 	}
 
-	void Leaderboard::NextPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info)
+	void Leaderboard::Refresh([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
+	{
+		StartRefresh(CurrentOffset);
+	}
+
+	void Leaderboard::RefreshFirstPage([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
+	{
+		const auto mapName = GetCurrentMapName();
+		StartRefresh(mapName == CurrentMap ? CurrentOffset : 0);
+	}
+
+	void Leaderboard::PreviousPage([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
+	{
+		StartRefresh(std::max(0, CurrentOffset - DefaultLimit));
+	}
+
+	void Leaderboard::NextPage([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
 	{
 		if (!HasNextPage)
 		{
-			UILeaderboardStatus.set("^3No next stats page loaded by the API.");
 			UpdatePageDvar();
 			return;
 		}
 
-		++CurrentPage;
-		Refresh(token, info);
+		StartRefresh(NextOffset);
 	}
 
-	void Leaderboard::ParseResponse(const std::string& response, const std::string& mapName)
+	void Leaderboard::ParseResponse(const std::string& response)
 	{
 		Entries.clear();
 		HasNextPage = false;
+		NextOffset = -1;
+		Loading = false;
+		UILeaderboardLoadingIndicator.set("");
 
 		rapidjson::Document doc{};
 		doc.Parse(response);
 
-		if (doc.HasParseError())
+		if (doc.HasParseError() || !doc.IsObject())
 		{
-			UILeaderboardStatus.set("^1Stats response parse error.");
-			UILeaderboardFirst.set("The stats API returned invalid JSON.");
-			UpdatePageDvar();
-			return;
-		}
-
-		if (!doc.IsObject())
-		{
-			UILeaderboardStatus.set("^1Invalid stats response format.");
-			UILeaderboardFirst.set("Expected a JSON object from /matches/data.");
+			UILeaderboardLoadingIndicator.set("Parse error");
 			UpdatePageDvar();
 			return;
 		}
 
 		if (!doc.HasMember("items") || !doc["items"].IsArray())
 		{
-			UILeaderboardStatus.set("^1Stats response has no items.");
-			UILeaderboardFirst.set("JSON has no items array.");
+			UILeaderboardLoadingIndicator.set("No entries");
+			TotalItems = 0;
 			UpdatePageDvar();
 			return;
 		}
 
-		const auto& items = doc["items"];
-		HasNextPage = items.Size() >= static_cast<rapidjson::SizeType>(DefaultPerPage);
+		// Try to read total items if provided by the API
+		TotalItems = GetJsonInt(doc, "total", -1);
+		if (TotalItems < 0) TotalItems = GetJsonInt(doc, "total_items", -1);
+		if (TotalItems < 0) TotalItems = GetJsonInt(doc, "total_count", -1);
 
-		std::unordered_map<std::string, Entry> bestEntries;
+		NextOffset = GetJsonInt(doc, "next_offset", -1);
+		HasNextPage = NextOffset >= 0;
+
+		const auto& items = doc["items"];
+		Entries.reserve(items.Size());
 
 		for (const auto& item : items.GetArray())
 		{
@@ -257,9 +285,9 @@ namespace Components
 
 			Entry entry{};
 			entry.guid = GetJsonString(item, "guid");
-			entry.player = GetJsonString(item, "name", GetJsonString(item, "player", "Unknown"));
-			entry.map = GetJsonString(item, "map", mapName.data());
-			entry.round = GetJsonInt(item, "round");
+			entry.player = GetJsonString(item, "player", GetJsonString(item, "name", "Unknown"));
+			entry.map = GetJsonString(item, "map", "Unknown");
+			entry.round = GetJsonInt(item, "round", GetJsonInt(item, "metric_value"));
 			entry.zombiemode = GetJsonString(item, "zombiemode");
 			entry.players = GetJsonInt(item, "players");
 			entry.playerRank = GetJsonString(item, "rank");
@@ -270,55 +298,20 @@ namespace Components
 			entry.exfiltrated = GetJsonInt(item, "exfiltrated");
 			entry.time = GetJsonFloat(item, "time");
 			entry.version = GetJsonString(item, "version");
-			entry.uploadedAt = GetJsonString(item, "uploaded_at", GetJsonString(item, "uploadedAt"));
-			entry.id = GetJsonInt(item, "id");
+			entry.uploadedAt = GetJsonString(item, "uploadedAt", GetJsonString(item, "uploaded_at"));
 
 			if (entry.player.empty()) entry.player = "Unknown";
-			if (entry.map.empty()) entry.map = mapName;
+			if (entry.map.empty()) entry.map = "Unknown";
 
-			const auto normalizedName = NormalizePlayerName(entry.player);
-			auto duplicate = bestEntries.find(normalizedName);
-			if (duplicate == bestEntries.end() || IsBetterEntry(entry, duplicate->second))
-			{
-				bestEntries[normalizedName] = entry;
-			}
+			Entries.push_back(entry);
 		}
-
-		Entries.reserve(bestEntries.size());
-		for (auto& entry : bestEntries)
-		{
-			Entries.push_back(std::move(entry.second));
-		}
-
-		std::sort(Entries.begin(), Entries.end(), [](const Entry& a, const Entry& b)
-			{
-				return IsBetterEntry(a, b);
-			});
-
-		UpdatePageDvar();
 
 		if (Entries.empty())
 		{
-			UILeaderboardStatus.set(Utils::String::VA("^3No stats found for %s on page %i.", mapName.data(), CurrentPage));
-			UILeaderboardFirst.set("Try refreshing after players have uploaded stats for this map.");
+			UILeaderboardLoadingIndicator.set("No entries");
 		}
-		else
-		{
-			const auto& first = Entries[0];
-			const std::string firstTime = FormatSeconds(first.time);
-			const auto removedDuplicates = static_cast<unsigned int>(items.Size() - Entries.size());
-			UILeaderboardStatus.set(Utils::String::VA("^2Loaded %u unique players for %s, page %i. Removed %u duplicate rows.",
-				static_cast<unsigned int>(Entries.size()),
-				mapName.data(),
-				CurrentPage,
-				removedDuplicates));
-			UILeaderboardFirst.set(Utils::String::VA("Best: %s | Round %i | Score %i | Kills %i | Time %s",
-				first.player.data(),
-				first.round,
-				first.score,
-				first.kills,
-				firstTime.data()));
-		}
+
+		UpdatePageDvar();
 	}
 
 	unsigned int Leaderboard::GetEntryCount()
@@ -335,9 +328,7 @@ namespace Components
 			case 0:
 				return "--";
 			case 1:
-				return "No stats loaded";
-			case 3:
-				return UILeaderboardStatus.get<const char*>();
+				return Loading ? "Loading leaderboard" : "No leaderboard entries";
 			default:
 				return "";
 			}
@@ -353,24 +344,22 @@ namespace Components
 		switch (column)
 		{
 		case 0:
-			return entry.player.data();
+			return Utils::String::VA("#%u", static_cast<unsigned int>(CurrentOffset + index + 1));
 		case 1:
-			return Utils::String::VA("%i", entry.round);
+			return entry.player.data();
 		case 2:
-			return entry.zombiemode.data();
+			return Utils::String::VA("%i", entry.round);
 		case 3:
-			return Utils::String::VA("%i", entry.players);
+			return entry.map.data();
 		case 4:
-			return Utils::String::VA("%i", entry.score);
+			return Utils::String::VA("%i", entry.players);
 		case 5:
-			return Utils::String::VA("%i", entry.kills);
+			return Utils::String::VA("%i", entry.score);
 		case 6:
-			return Utils::String::VA("%i", entry.downs);
+			return Utils::String::VA("%i", entry.kills);
 		case 7:
-			return Utils::String::VA("%i", entry.revives);
+			return Utils::String::VA("%i", entry.downs);
 		case 8:
-			return Utils::String::VA("%i", entry.exfiltrated);
-		case 9:
 			return FormatSeconds(entry.time);
 		default:
 			return "";
@@ -388,10 +377,9 @@ namespace Components
 
 		Events::OnDvarInit([]
 			{
-				UILeaderboardStatus = Dvar::Register<const char*>("ui_leaderboard_status", "", Game::DVAR_NONE, "Current status for the map stats menu.");
-				UILeaderboardFirst = Dvar::Register<const char*>("ui_leaderboard_first", "", Game::DVAR_NONE, "Debug line for the first returned map stats row.");
-				UILeaderboardMap = Dvar::Register<const char*>("ui_leaderboard_map", "", Game::DVAR_NONE, "Current map used by the map stats menu.");
-				UILeaderboardPage = Dvar::Register<const char*>("ui_leaderboard_page", "Page 1", Game::DVAR_NONE, "Current page used by the map stats menu.");
+				UILeaderboardMap = Dvar::Register<const char*>("ui_leaderboard_map", "", Game::DVAR_NONE, "Current map used by the best rounds leaderboard.");
+				UILeaderboardPage = Dvar::Register<const char*>("ui_leaderboard_page", "Page 1", Game::DVAR_NONE, "Current page used by the best rounds leaderboard.");
+				UILeaderboardLoadingIndicator = Dvar::Register<const char*>("ui_leaderboard_loading_indicator", "", Game::DVAR_NONE, "Animated loading indicator for the best rounds leaderboard.");
 			});
 
 		UIFeeder::Add(FeederId, Leaderboard::GetEntryCount, Leaderboard::GetEntryText, Leaderboard::SelectEntry);
@@ -399,6 +387,8 @@ namespace Components
 		UIScript::Add("RefreshLeaderboardPage", Leaderboard::Refresh);
 		UIScript::Add("PreviousLeaderboardPage", Leaderboard::PreviousPage);
 		UIScript::Add("NextLeaderboardPage", Leaderboard::NextPage);
+
+		Scheduler::Loop(Leaderboard::UpdateLoadingStatus, Scheduler::Pipeline::MAIN, 250ms);
 	}
 
 	Leaderboard::~Leaderboard()

--- a/src/Utils/Leaderboard.cpp
+++ b/src/Utils/Leaderboard.cpp
@@ -10,21 +10,23 @@
 #include "Leaderboard.hpp"
 
 #include <rapidjson/document.h>
+#include <Components/Modules/Party.hpp>
 
 namespace Components
 {
 	std::vector<Leaderboard::Entry> Leaderboard::Entries;
 	Dvar::Var Leaderboard::UILeaderboardMap;
 	Dvar::Var Leaderboard::UILeaderboardPage;
-	Dvar::Var Leaderboard::UILeaderboardLoadingIndicator;
+	Dvar::Var Leaderboard::UILeaderboardPlayerStatus;
 	int Leaderboard::CurrentOffset = 0;
 	int Leaderboard::NextOffset = -1;
-int Leaderboard::TotalItems = -1;
+	int Leaderboard::TotalItems = -1;
 	bool Leaderboard::HasNextPage = false;
 	bool Leaderboard::Loading = false;
 	unsigned int Leaderboard::RequestSerial = 0;
-	int Leaderboard::LoadingFrame = 0;
 	std::string Leaderboard::CurrentMap;
+	int Leaderboard::LastKnownRank = 0;
+	bool Leaderboard::IsSearching = false;
 
 	const char* Leaderboard::GetApiKey()
 	{
@@ -61,14 +63,22 @@ int Leaderboard::TotalItems = -1;
 		const auto total = std::max(0, static_cast<int>(seconds));
 		const auto hours = total / 3600;
 		const auto minutes = (total % 3600) / 60;
-		const auto secs = total % 60;
+
+		static char timeBuffers[16][32];
+		static size_t currentBufferIndex = 0;
+		char* targetBuffer = timeBuffers[currentBufferIndex];
+		currentBufferIndex = (currentBufferIndex + 1) % 16;
 
 		if (hours > 0)
 		{
-			return Utils::String::VA("%02i:%02i:%02i", hours, minutes, secs);
+			std::snprintf(targetBuffer, 32, "%ih %im", hours, minutes);
+		}
+		else
+		{
+			std::snprintf(targetBuffer, 32, "%im", minutes);
 		}
 
-		return Utils::String::VA("%02i:%02i", minutes, secs);
+		return targetBuffer;
 	}
 
 	void Leaderboard::UpdatePageDvar()
@@ -135,21 +145,6 @@ int Leaderboard::TotalItems = -1;
 		return encoded;
 	}
 
-	void Leaderboard::UpdateLoadingStatus()
-	{
-		if (!Loading)
-		{
-			return;
-		}
-
-		constexpr const char* spinner[] = { "|", "/", "-", "\\" };
-		constexpr const char* dots[] = { ".", "..", "..." };
-		UILeaderboardLoadingIndicator.set(Utils::String::VA("%s Loading%s",
-			spinner[LoadingFrame % std::size(spinner)],
-			dots[LoadingFrame % std::size(dots)]));
-		LoadingFrame++;
-	}
-
 	void Leaderboard::StartRefresh(int offset)
 	{
 		const auto mapName = GetCurrentMapName();
@@ -162,23 +157,24 @@ int Leaderboard::TotalItems = -1;
 			Loading = false;
 			HasNextPage = false;
 			NextOffset = -1;
-			UILeaderboardLoadingIndicator.set("No map");
 			UpdatePageDvar();
 			Toast::Show("cardicon_redhand", "^1Leaderboard", "Could not detect the current map for leaderboard lookup.", 5000);
 			return;
 		}
 
-		CurrentMap = mapName;
+		if (mapName != CurrentMap)
+		{
+			LastKnownRank = 0;
+			CurrentMap = mapName;
+		}
+
 		CurrentOffset = std::max(0, offset);
 		const auto requestId = ++RequestSerial;
-		Entries.clear();
 		HasNextPage = false;
 		NextOffset = -1;
 		UpdatePageDvar();
 
 		Loading = true;
-		LoadingFrame = 0;
-		UpdateLoadingStatus();
 
 		const auto url = CurrentOffset > 0
 			? std::format("https://stats.zw3.eu/leaderboard/best-rounds?limit={}&map={}&offset={}", DefaultLimit, UrlEncode(mapName), CurrentOffset)
@@ -198,11 +194,9 @@ int Leaderboard::TotalItems = -1;
 						}
 
 						Loading = false;
-						UILeaderboardLoadingIndicator.set("");
 
 						if (reply.empty())
 						{
-							UILeaderboardLoadingIndicator.set("Load failed");
 							Toast::Show("cardicon_redhand", "^1Leaderboard", "Could not get a response from the stats API.", 5000);
 							return;
 						}
@@ -245,27 +239,23 @@ int Leaderboard::TotalItems = -1;
 		HasNextPage = false;
 		NextOffset = -1;
 		Loading = false;
-		UILeaderboardLoadingIndicator.set("");
 
 		rapidjson::Document doc{};
 		doc.Parse(response);
 
 		if (doc.HasParseError() || !doc.IsObject())
 		{
-			UILeaderboardLoadingIndicator.set("Parse error");
 			UpdatePageDvar();
 			return;
 		}
 
 		if (!doc.HasMember("items") || !doc["items"].IsArray())
 		{
-			UILeaderboardLoadingIndicator.set("No entries");
 			TotalItems = 0;
 			UpdatePageDvar();
 			return;
 		}
 
-		// Try to read total items if provided by the API
 		TotalItems = GetJsonInt(doc, "total", -1);
 		if (TotalItems < 0) TotalItems = GetJsonInt(doc, "total_items", -1);
 		if (TotalItems < 0) TotalItems = GetJsonInt(doc, "total_count", -1);
@@ -306,12 +296,85 @@ int Leaderboard::TotalItems = -1;
 			Entries.push_back(entry);
 		}
 
-		if (Entries.empty())
+		UpdatePageDvar();
+		UpdateLocalPlayerStatus();
+
+		if (LastKnownRank == 0 && CurrentOffset == 0 && !IsSearching)
 		{
-			UILeaderboardLoadingIndicator.set("No entries");
+			FetchRankBackground(0);
+		}
+	}
+
+	void Leaderboard::FetchRankBackground(int offset)
+	{
+		if (CurrentMap.empty())
+		{
+			CurrentMap = GetCurrentMapName();
 		}
 
-		UpdatePageDvar();
+		if (CurrentMap.empty()) return;
+
+		if (offset == 0) {
+			IsSearching = true;
+		}
+
+		const auto url = std::format("https://stats.zw3.eu/leaderboard/best-rounds?limit={}&map={}&offset={}", DefaultLimit, UrlEncode(CurrentMap), offset);
+
+		Scheduler::Once([url, offset]
+			{
+				const auto reply = Utils::WebIO("zw3-rank-bg", url).get();
+				Scheduler::Once([reply, offset]
+					{
+						rapidjson::Document doc{};
+						doc.Parse(reply);
+						if (doc.HasParseError() || !doc.HasMember("items")) return;
+
+						const auto& items = doc["items"];
+						const auto localXuid = Party::GetLocalPlayerXUID();
+						const std::string localXuidHex = Utils::String::VA("%llX", static_cast<unsigned long long>(localXuid));
+
+						for (size_t i = 0; i < items.Size(); ++i)
+						{
+							const auto& item = items[i];
+							std::string guid = GetJsonString(item, "guid");
+
+							if (guid == localXuidHex)
+							{
+								LastKnownRank = offset + static_cast<int>(i) + 1;
+								IsSearching = false;
+								UpdateLocalPlayerStatus();
+								return;
+							}
+						}
+
+						int nextOffset = GetJsonInt(doc, "next_offset", -1);
+						if (nextOffset >= 0)
+						{
+							FetchRankBackground(nextOffset);
+						}
+						else
+						{
+							IsSearching = false;
+							UpdateLocalPlayerStatus();
+						}
+					}, Scheduler::Pipeline::MAIN);
+			}, Scheduler::Pipeline::ASYNC);
+	}
+
+	void Leaderboard::UpdateLocalPlayerStatus()
+	{
+		if (LastKnownRank > 0)
+		{
+			UILeaderboardPlayerStatus.set(Utils::String::VA("You are currently: ^3#%u", (unsigned int)LastKnownRank));
+		}
+		else if (!IsSearching)
+		{
+			UILeaderboardPlayerStatus.set("You are not on the leaderboard for this map yet.");
+		}
+		else
+		{
+			UILeaderboardPlayerStatus.set("");
+		}
 	}
 
 	unsigned int Leaderboard::GetEntryCount()
@@ -328,7 +391,7 @@ int Leaderboard::TotalItems = -1;
 			case 0:
 				return "--";
 			case 1:
-				return Loading ? "Loading leaderboard" : "No leaderboard entries";
+				return Loading ? "Loading leaderboard..." : "No leaderboard entries";
 			default:
 				return "";
 			}
@@ -346,21 +409,19 @@ int Leaderboard::TotalItems = -1;
 		case 0:
 			return Utils::String::VA("#%u", static_cast<unsigned int>(CurrentOffset + index + 1));
 		case 1:
-			return entry.player.data();
-		case 2:
 			return Utils::String::VA("%i", entry.round);
+		case 2:
+			return entry.player.data();
 		case 3:
-			return entry.map.data();
-		case 4:
-			return Utils::String::VA("%i", entry.players);
-		case 5:
 			return Utils::String::VA("%i", entry.score);
-		case 6:
+		case 4:
 			return Utils::String::VA("%i", entry.kills);
-		case 7:
+		case 5:
 			return Utils::String::VA("%i", entry.downs);
-		case 8:
+		case 6:
 			return FormatSeconds(entry.time);
+		case 7:
+			return Utils::String::VA("%i/4", entry.players);
 		default:
 			return "";
 		}
@@ -368,7 +429,6 @@ int Leaderboard::TotalItems = -1;
 
 	void Leaderboard::SelectEntry([[maybe_unused]] unsigned int index)
 	{
-		// Optional later: open player details for the selected stats row.
 	}
 
 	Leaderboard::Leaderboard()
@@ -379,20 +439,20 @@ int Leaderboard::TotalItems = -1;
 			{
 				UILeaderboardMap = Dvar::Register<const char*>("ui_leaderboard_map", "", Game::DVAR_NONE, "Current map used by the best rounds leaderboard.");
 				UILeaderboardPage = Dvar::Register<const char*>("ui_leaderboard_page", "Page 1", Game::DVAR_NONE, "Current page used by the best rounds leaderboard.");
-				UILeaderboardLoadingIndicator = Dvar::Register<const char*>("ui_leaderboard_loading_indicator", "", Game::DVAR_NONE, "Animated loading indicator for the best rounds leaderboard.");
+				UILeaderboardPlayerStatus = Dvar::Register<const char*>("ui_leaderboard_player_status", "", Game::DVAR_NONE, "Local player leaderboard status.");
+				UILeaderboardPlayerStatus.set("");
 			});
 
 		UIFeeder::Add(FeederId, Leaderboard::GetEntryCount, Leaderboard::GetEntryText, Leaderboard::SelectEntry);
 		UIScript::Add("RefreshLeaderboard", Leaderboard::RefreshFirstPage);
-		UIScript::Add("RefreshLeaderboardPage", Leaderboard::Refresh);
+		//UIScript::Add("RefreshLeaderboardPage", Leaderboard::Refresh);
 		UIScript::Add("PreviousLeaderboardPage", Leaderboard::PreviousPage);
 		UIScript::Add("NextLeaderboardPage", Leaderboard::NextPage);
-
-		Scheduler::Loop(Leaderboard::UpdateLoadingStatus, Scheduler::Pipeline::MAIN, 250ms);
 	}
 
 	Leaderboard::~Leaderboard()
 	{
+		LastKnownRank = 0;
 		Entries.clear();
 	}
 }

--- a/src/Utils/Leaderboard.cpp
+++ b/src/Utils/Leaderboard.cpp
@@ -1,9 +1,408 @@
+#include <Utils/WebIO.hpp>
+
+#include <Components/Modules/Dvar.hpp>
+#include <Components/Modules/Events.hpp>
+#include <Components/Modules/Logger.hpp>
+#include <Components/Modules/Toast.hpp>
+#include <Components/Modules/UIFeeder.hpp>
+#include <Components/Modules/UIScript.hpp>
+
 #include "Leaderboard.hpp"
 
-namespace Utils::Leaderboard
+#include <rapidjson/document.h>
+
+namespace Components
 {
-	const char* GetApiKey()
+	std::vector<Leaderboard::Entry> Leaderboard::Entries;
+	Dvar::Var Leaderboard::UILeaderboardStatus;
+	Dvar::Var Leaderboard::UILeaderboardFirst;
+	Dvar::Var Leaderboard::UILeaderboardMap;
+	Dvar::Var Leaderboard::UILeaderboardPage;
+	int Leaderboard::CurrentPage = DefaultPage;
+	bool Leaderboard::HasNextPage = false;
+
+	const char* Leaderboard::GetApiKey()
 	{
 		return "zw3_YbEL1IsJUEGPW6cy1wN8q35WsLBLXTYp548WSdUfVJDALM6drgFxM3KTmAeIigfxiylwjlraODV8Fr7AzyVcWSKoQBH3ejJ07A0GCnaHq27ZVy5sKed6VoD55l3eS0N1x762nHcPCYUySB5F9oS92ObaxmYzigGAYlU9TiRiiibs28A3TJtjUeosaUbrTWPcd6EJAu2vqOdRyRzOL5mmzgN5EKZ9NDprTmNq3v98pWvf6HeoRFkk6RF9AxllgEMI";
+	}
+
+	static const char* GetJsonString(const rapidjson::Value& object, const char* key, const char* fallback = "")
+	{
+		if (object.HasMember(key) && object[key].IsString())
+		{
+			return object[key].GetString();
+		}
+
+		return fallback;
+	}
+
+	static int GetJsonInt(const rapidjson::Value& object, const char* key, int fallback = 0)
+	{
+		if (!object.HasMember(key)) return fallback;
+		if (object[key].IsInt()) return object[key].GetInt();
+		if (object[key].IsNumber()) return static_cast<int>(object[key].GetDouble());
+		return fallback;
+	}
+
+	static float GetJsonFloat(const rapidjson::Value& object, const char* key, float fallback = 0.0f)
+	{
+		if (!object.HasMember(key)) return fallback;
+		if (object[key].IsNumber()) return static_cast<float>(object[key].GetDouble());
+		return fallback;
+	}
+
+	static const char* FormatSeconds(float seconds)
+	{
+		const auto total = std::max(0, static_cast<int>(seconds));
+		const auto hours = total / 3600;
+		const auto minutes = (total % 3600) / 60;
+		const auto secs = total % 60;
+
+		if (hours > 0)
+		{
+			return Utils::String::VA("%02i:%02i:%02i", hours, minutes, secs);
+		}
+
+		return Utils::String::VA("%02i:%02i", minutes, secs);
+	}
+
+	static std::string NormalizePlayerName(std::string player)
+	{
+		Utils::String::Trim(player);
+		std::transform(player.begin(), player.end(), player.begin(), [](const unsigned char c)
+			{
+				return static_cast<char>(std::tolower(c));
+			});
+
+		return player;
+	}
+
+	bool Leaderboard::IsBetterEntry(const Entry& candidate, const Entry& current)
+	{
+		if (candidate.round != current.round) return candidate.round > current.round;
+		if (candidate.score != current.score) return candidate.score > current.score;
+		if (candidate.kills != current.kills) return candidate.kills > current.kills;
+		if (candidate.downs != current.downs) return candidate.downs < current.downs;
+		if (candidate.revives != current.revives) return candidate.revives > current.revives;
+		if (candidate.exfiltrated != current.exfiltrated) return candidate.exfiltrated > current.exfiltrated;
+		return candidate.time < current.time;
+	}
+
+	void Leaderboard::UpdatePageDvar()
+	{
+		UILeaderboardPage.set(Utils::String::VA("Page %i%s", CurrentPage, HasNextPage ? "" : " (last)"));
+	}
+
+	std::string Leaderboard::GetCurrentMapName()
+	{
+		const auto* mapname = Game::Dvar_FindVar("mapname");
+		if (mapname && mapname->current.string && *mapname->current.string)
+		{
+			return mapname->current.string;
+		}
+
+		if (Game::sv_mapname && *Game::sv_mapname && (*Game::sv_mapname)->current.string && *(*Game::sv_mapname)->current.string)
+		{
+			return (*Game::sv_mapname)->current.string;
+		}
+
+		if (Game::ui_mapname && *Game::ui_mapname && (*Game::ui_mapname)->current.string && *(*Game::ui_mapname)->current.string)
+		{
+			return (*Game::ui_mapname)->current.string;
+		}
+
+		return {};
+	}
+
+	std::string Leaderboard::UrlEncode(const std::string& value)
+	{
+		std::string encoded;
+		encoded.reserve(value.size());
+
+		constexpr auto* hex = "0123456789ABCDEF";
+		for (const auto c : value)
+		{
+			const auto byte = static_cast<unsigned char>(c);
+			if (std::isalnum(byte) || byte == '-' || byte == '_' || byte == '.' || byte == '~')
+			{
+				encoded.push_back(static_cast<char>(byte));
+			}
+			else
+			{
+				encoded.push_back('%');
+				encoded.push_back(hex[byte >> 4]);
+				encoded.push_back(hex[byte & 0x0F]);
+			}
+		}
+
+		return encoded;
+	}
+
+	void Leaderboard::Refresh([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info)
+	{
+		Entries.clear();
+		UpdatePageDvar();
+
+		const auto mapName = GetCurrentMapName();
+		UILeaderboardMap.set(mapName.empty() ? "Unknown" : mapName);
+
+		if (mapName.empty())
+		{
+			UILeaderboardStatus.set("^1Could not detect current map.");
+			UILeaderboardFirst.set("The mapname, sv_mapname, and ui_mapname dvars are empty.");
+			Toast::Show("cardicon_redhand", "^1Stats", "Could not detect the current map for stats lookup.", 5000);
+			return;
+		}
+
+		UILeaderboardStatus.set(Utils::String::VA("Loading stats for %s, page %i...", mapName.data(), CurrentPage));
+		UILeaderboardFirst.set("Waiting for stats API response...");
+
+		const auto url = std::format(
+			"https://stats.zw3.eu/matches/data?page={}&per_page={}&period={}&map={}",
+			CurrentPage,
+			DefaultPerPage,
+			DefaultPeriod,
+			UrlEncode(mapName));
+
+		Utils::WebIO::params headers;
+		headers["Content-Type"] = "application/json";
+		const auto reply = Utils::WebIO("zw3-map-stats", url).setTimeout(5000)->get(headers);
+
+		if (reply.empty())
+		{
+			UILeaderboardStatus.set("^1Could not load stats.");
+			UILeaderboardFirst.set(Utils::String::VA("No HTTP response for map %s, page %i.", mapName.data(), CurrentPage));
+			Toast::Show("cardicon_redhand", "^1Stats", "Could not get a response from the stats API.", 5000);
+			return;
+		}
+
+		ParseResponse(reply, mapName);
+	}
+
+	void Leaderboard::RefreshFirstPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info)
+	{
+		CurrentPage = DefaultPage;
+		Refresh(token, info);
+	}
+
+	void Leaderboard::PreviousPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info)
+	{
+		if (CurrentPage <= DefaultPage)
+		{
+			UILeaderboardStatus.set("^3Already on the first stats page.");
+			UpdatePageDvar();
+			return;
+		}
+
+		--CurrentPage;
+		Refresh(token, info);
+	}
+
+	void Leaderboard::NextPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info)
+	{
+		if (!HasNextPage)
+		{
+			UILeaderboardStatus.set("^3No next stats page loaded by the API.");
+			UpdatePageDvar();
+			return;
+		}
+
+		++CurrentPage;
+		Refresh(token, info);
+	}
+
+	void Leaderboard::ParseResponse(const std::string& response, const std::string& mapName)
+	{
+		Entries.clear();
+		HasNextPage = false;
+
+		rapidjson::Document doc{};
+		doc.Parse(response);
+
+		if (doc.HasParseError())
+		{
+			UILeaderboardStatus.set("^1Stats response parse error.");
+			UILeaderboardFirst.set("The stats API returned invalid JSON.");
+			UpdatePageDvar();
+			return;
+		}
+
+		if (!doc.IsObject())
+		{
+			UILeaderboardStatus.set("^1Invalid stats response format.");
+			UILeaderboardFirst.set("Expected a JSON object from /matches/data.");
+			UpdatePageDvar();
+			return;
+		}
+
+		if (!doc.HasMember("items") || !doc["items"].IsArray())
+		{
+			UILeaderboardStatus.set("^1Stats response has no items.");
+			UILeaderboardFirst.set("JSON has no items array.");
+			UpdatePageDvar();
+			return;
+		}
+
+		const auto& items = doc["items"];
+		HasNextPage = items.Size() >= static_cast<rapidjson::SizeType>(DefaultPerPage);
+
+		std::unordered_map<std::string, Entry> bestEntries;
+
+		for (const auto& item : items.GetArray())
+		{
+			if (!item.IsObject())
+			{
+				continue;
+			}
+
+			Entry entry{};
+			entry.guid = GetJsonString(item, "guid");
+			entry.player = GetJsonString(item, "name", GetJsonString(item, "player", "Unknown"));
+			entry.map = GetJsonString(item, "map", mapName.data());
+			entry.round = GetJsonInt(item, "round");
+			entry.zombiemode = GetJsonString(item, "zombiemode");
+			entry.players = GetJsonInt(item, "players");
+			entry.playerRank = GetJsonString(item, "rank");
+			entry.score = GetJsonInt(item, "score");
+			entry.kills = GetJsonInt(item, "kills");
+			entry.downs = GetJsonInt(item, "downs");
+			entry.revives = GetJsonInt(item, "revives");
+			entry.exfiltrated = GetJsonInt(item, "exfiltrated");
+			entry.time = GetJsonFloat(item, "time");
+			entry.version = GetJsonString(item, "version");
+			entry.uploadedAt = GetJsonString(item, "uploaded_at", GetJsonString(item, "uploadedAt"));
+			entry.id = GetJsonInt(item, "id");
+
+			if (entry.player.empty()) entry.player = "Unknown";
+			if (entry.map.empty()) entry.map = mapName;
+
+			const auto normalizedName = NormalizePlayerName(entry.player);
+			auto duplicate = bestEntries.find(normalizedName);
+			if (duplicate == bestEntries.end() || IsBetterEntry(entry, duplicate->second))
+			{
+				bestEntries[normalizedName] = entry;
+			}
+		}
+
+		Entries.reserve(bestEntries.size());
+		for (auto& entry : bestEntries)
+		{
+			Entries.push_back(std::move(entry.second));
+		}
+
+		std::sort(Entries.begin(), Entries.end(), [](const Entry& a, const Entry& b)
+			{
+				return IsBetterEntry(a, b);
+			});
+
+		UpdatePageDvar();
+
+		if (Entries.empty())
+		{
+			UILeaderboardStatus.set(Utils::String::VA("^3No stats found for %s on page %i.", mapName.data(), CurrentPage));
+			UILeaderboardFirst.set("Try refreshing after players have uploaded stats for this map.");
+		}
+		else
+		{
+			const auto& first = Entries[0];
+			const std::string firstTime = FormatSeconds(first.time);
+			const auto removedDuplicates = static_cast<unsigned int>(items.Size() - Entries.size());
+			UILeaderboardStatus.set(Utils::String::VA("^2Loaded %u unique players for %s, page %i. Removed %u duplicate rows.",
+				static_cast<unsigned int>(Entries.size()),
+				mapName.data(),
+				CurrentPage,
+				removedDuplicates));
+			UILeaderboardFirst.set(Utils::String::VA("Best: %s | Round %i | Score %i | Kills %i | Time %s",
+				first.player.data(),
+				first.round,
+				first.score,
+				first.kills,
+				firstTime.data()));
+		}
+	}
+
+	unsigned int Leaderboard::GetEntryCount()
+	{
+		return Entries.empty() ? 1u : static_cast<unsigned int>(Entries.size());
+	}
+
+	const char* Leaderboard::GetEntryText(unsigned int index, int column)
+	{
+		if (Entries.empty())
+		{
+			switch (column)
+			{
+			case 0:
+				return "--";
+			case 1:
+				return "No stats loaded";
+			case 3:
+				return UILeaderboardStatus.get<const char*>();
+			default:
+				return "";
+			}
+		}
+
+		if (index >= Entries.size())
+		{
+			return "";
+		}
+
+		const auto& entry = Entries[index];
+
+		switch (column)
+		{
+		case 0:
+			return entry.player.data();
+		case 1:
+			return Utils::String::VA("%i", entry.round);
+		case 2:
+			return entry.zombiemode.data();
+		case 3:
+			return Utils::String::VA("%i", entry.players);
+		case 4:
+			return Utils::String::VA("%i", entry.score);
+		case 5:
+			return Utils::String::VA("%i", entry.kills);
+		case 6:
+			return Utils::String::VA("%i", entry.downs);
+		case 7:
+			return Utils::String::VA("%i", entry.revives);
+		case 8:
+			return Utils::String::VA("%i", entry.exfiltrated);
+		case 9:
+			return FormatSeconds(entry.time);
+		default:
+			return "";
+		}
+	}
+
+	void Leaderboard::SelectEntry([[maybe_unused]] unsigned int index)
+	{
+		// Optional later: open player details for the selected stats row.
+	}
+
+	Leaderboard::Leaderboard()
+	{
+		if (Dedicated::IsEnabled()) return;
+
+		Events::OnDvarInit([]
+			{
+				UILeaderboardStatus = Dvar::Register<const char*>("ui_leaderboard_status", "", Game::DVAR_NONE, "Current status for the map stats menu.");
+				UILeaderboardFirst = Dvar::Register<const char*>("ui_leaderboard_first", "", Game::DVAR_NONE, "Debug line for the first returned map stats row.");
+				UILeaderboardMap = Dvar::Register<const char*>("ui_leaderboard_map", "", Game::DVAR_NONE, "Current map used by the map stats menu.");
+				UILeaderboardPage = Dvar::Register<const char*>("ui_leaderboard_page", "Page 1", Game::DVAR_NONE, "Current page used by the map stats menu.");
+			});
+
+		UIFeeder::Add(FeederId, Leaderboard::GetEntryCount, Leaderboard::GetEntryText, Leaderboard::SelectEntry);
+		UIScript::Add("RefreshLeaderboard", Leaderboard::RefreshFirstPage);
+		UIScript::Add("RefreshLeaderboardPage", Leaderboard::Refresh);
+		UIScript::Add("PreviousLeaderboardPage", Leaderboard::PreviousPage);
+		UIScript::Add("NextLeaderboardPage", Leaderboard::NextPage);
+	}
+
+	Leaderboard::~Leaderboard()
+	{
+		Entries.clear();
 	}
 }

--- a/src/Utils/Leaderboard.hpp
+++ b/src/Utils/Leaderboard.hpp
@@ -27,31 +27,34 @@ namespace Components
 			float time = 0.0f;
 			std::string version;
 			std::string uploadedAt;
-			int id = 0;
 		};
 
 		static constexpr float FeederId = 70.0f;
-		static constexpr int DefaultPage = 1;
-		static constexpr int DefaultPerPage = 50;
-		static constexpr int DefaultPeriod = 30;
+		static constexpr int DefaultLimit = 25;
 
 		static std::vector<Entry> Entries;
-		static Dvar::Var UILeaderboardStatus;
-		static Dvar::Var UILeaderboardFirst;
 		static Dvar::Var UILeaderboardMap;
 		static Dvar::Var UILeaderboardPage;
-		static int CurrentPage;
+		static Dvar::Var UILeaderboardLoadingIndicator;
+		static int CurrentOffset;
+		static int NextOffset;
+		static int TotalItems;
 		static bool HasNextPage;
+		static bool Loading;
+		static unsigned int RequestSerial;
+		static int LoadingFrame;
+		static std::string CurrentMap;
 
-		static bool IsBetterEntry(const Entry& candidate, const Entry& current);
 		static void UpdatePageDvar();
 		static std::string GetCurrentMapName();
 		static std::string UrlEncode(const std::string& value);
+		static void StartRefresh(int offset);
+		static void UpdateLoadingStatus();
 		static void Refresh([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info);
-		static void RefreshFirstPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info);
-		static void PreviousPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info);
-		static void NextPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info);
-		static void ParseResponse(const std::string& response, const std::string& mapName);
+		static void RefreshFirstPage([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info);
+		static void PreviousPage([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info);
+		static void NextPage([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info);
+		static void ParseResponse(const std::string& response);
 
 		static unsigned int GetEntryCount();
 		static const char* GetEntryText(unsigned int index, int column);

--- a/src/Utils/Leaderboard.hpp
+++ b/src/Utils/Leaderboard.hpp
@@ -1,6 +1,60 @@
 #pragma once
 
-namespace Utils::Leaderboard
+namespace Components
 {
-	const char* GetApiKey();
+	class Leaderboard : public Component
+	{
+	public:
+		Leaderboard();
+		~Leaderboard();
+		static const char* GetApiKey();
+
+	private:
+		struct Entry
+		{
+			std::string guid;
+			std::string player;
+			std::string map;
+			int round = 0;
+			std::string zombiemode;
+			int players = 0;
+			std::string playerRank;
+			int score = 0;
+			int kills = 0;
+			int downs = 0;
+			int revives = 0;
+			int exfiltrated = 0;
+			float time = 0.0f;
+			std::string version;
+			std::string uploadedAt;
+			int id = 0;
+		};
+
+		static constexpr float FeederId = 70.0f;
+		static constexpr int DefaultPage = 1;
+		static constexpr int DefaultPerPage = 50;
+		static constexpr int DefaultPeriod = 30;
+
+		static std::vector<Entry> Entries;
+		static Dvar::Var UILeaderboardStatus;
+		static Dvar::Var UILeaderboardFirst;
+		static Dvar::Var UILeaderboardMap;
+		static Dvar::Var UILeaderboardPage;
+		static int CurrentPage;
+		static bool HasNextPage;
+
+		static bool IsBetterEntry(const Entry& candidate, const Entry& current);
+		static void UpdatePageDvar();
+		static std::string GetCurrentMapName();
+		static std::string UrlEncode(const std::string& value);
+		static void Refresh([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info);
+		static void RefreshFirstPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info);
+		static void PreviousPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info);
+		static void NextPage([[maybe_unused]] const UIScript::Token& token, const Game::uiInfo_s* info);
+		static void ParseResponse(const std::string& response, const std::string& mapName);
+
+		static unsigned int GetEntryCount();
+		static const char* GetEntryText(unsigned int index, int column);
+		static void SelectEntry(unsigned int index);
+	};
 }

--- a/src/Utils/Leaderboard.hpp
+++ b/src/Utils/Leaderboard.hpp
@@ -30,12 +30,13 @@ namespace Components
 		};
 
 		static constexpr float FeederId = 70.0f;
-		static constexpr int DefaultLimit = 25;
+		static constexpr int DefaultLimit = 15;
 
 		static std::vector<Entry> Entries;
 		static Dvar::Var UILeaderboardMap;
 		static Dvar::Var UILeaderboardPage;
 		static Dvar::Var UILeaderboardLoadingIndicator;
+		static Dvar::Var UILeaderboardPlayerStatus;
 		static int CurrentOffset;
 		static int NextOffset;
 		static int TotalItems;
@@ -44,8 +45,11 @@ namespace Components
 		static unsigned int RequestSerial;
 		static int LoadingFrame;
 		static std::string CurrentMap;
+		static int LastKnownRank;
+		static bool IsSearching;
 
 		static void UpdatePageDvar();
+		static void UpdateLocalPlayerStatus();
 		static std::string GetCurrentMapName();
 		static std::string UrlEncode(const std::string& value);
 		static void StartRefresh(int offset);
@@ -54,6 +58,7 @@ namespace Components
 		static void RefreshFirstPage([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info);
 		static void PreviousPage([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info);
 		static void NextPage([[maybe_unused]] const UIScript::Token& token, [[maybe_unused]] const Game::uiInfo_s* info);
+		static void FetchRankBackground(int offset);
 		static void ParseResponse(const std::string& response);
 
 		static unsigned int GetEntryCount();

--- a/src/Utils/WebIO.cpp
+++ b/src/Utils/WebIO.cpp
@@ -325,7 +325,7 @@ namespace Utils
 		if (!params.contains("Content-Type"))
 		{
 			params["Content-Type"] = "application/json";
-			params["Authorization"] = "Bearer " + std::string(Utils::Leaderboard::GetApiKey());
+			params["Authorization"] = "Bearer " + std::string(Components::Leaderboard::GetApiKey());
 		}
 
 		std::string finalHeaders;


### PR DESCRIPTION
# New
- Implemented support for an in-game map leaderboard that is filtered by best rounds.
- Readd zw3 file cleanup on launch.

# Changes
- Updated zw3 branding.
- Updated clientVersion to 3.1.0 for fatal errors/exceptions.

# Bug Fixes
- Fixed an issue where SP map loadscreens would not update between loading.
- Fixed autosave popup appearing if joining another private match lobby (non-host).