### PR TITLE
Fix disk menu override handling and preserve custom connect.menu

### DIFF
--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -322,54 +322,6 @@ namespace Components
 		return menus;
 	}
 
-	// Add the RemoveMenuFromContext helper function (same as previous iteration)
-	void Menus::RemoveMenuFromContext(Game::UiContext* dc, Game::menuDef_t* menuToRemove)
-	{
-		if (!dc || !menuToRemove) return;
-
-		// Search for the menu in the context's main menu array
-		for (int i = 0; i < dc->menuCount; ++i)
-		{
-			if (dc->Menus[i] == menuToRemove)
-			{
-				DebugPrint("Removing menu {} from UI context {:X} at index {}",
-					menuToRemove->window.name, (unsigned int)dc, i);
-
-				// Shift elements left to fill the gap
-				for (int j = i; j < dc->menuCount - 1; ++j)
-				{
-					dc->Menus[j] = dc->Menus[j + 1];
-				}
-
-				// Clear the last element and decrement count
-				dc->Menus[--dc->menuCount] = nullptr;
-				// Adjust loop counter as we removed an element and shifted
-				i--;
-			}
-		}
-
-		// Also check and remove from the menu stack if present
-		for (int i = 0; i < dc->openMenuCount; ++i)
-		{
-			if (dc->menuStack[i] == menuToRemove)
-			{
-				DebugPrint("Removing menu {} from UI context {:X} stack at index {}",
-					menuToRemove->window.name, (unsigned int)dc, i);
-
-				// Shift elements left to fill the gap
-				for (int j = i; j < dc->openMenuCount - 1; ++j)
-				{
-					dc->menuStack[j] = dc->menuStack[j + 1];
-				}
-
-				// Clear the last element and decrement count
-				dc->menuStack[--dc->openMenuCount] = nullptr;
-				// Adjust loop counter as we removed an element and shifted
-				i--;
-			}
-		}
-	}
-
 
 	bool Menus::MenuAlreadyExists(const std::string& name)
 	{
@@ -658,57 +610,94 @@ namespace Components
 	void Menus::PrepareToUnloadMenu(Game::menuDef_t* menu)
 	{
 		const std::string name = menu->window.name;
-		Game::menuDef_t* originalMenu = nullptr;
-
-		// Check if this menu was an override we previously tracked
-		if (OverridenMenus.count(name)) {
-			originalMenu = OverridenMenus[name]; // This could be nullptr if it was an implicit override of an unknown pointer
-			DebugPrint("PrepareToUnloadMenu: Unloading menu '{}' ({:X}). Original was tracked as {:X}.", name, (unsigned int)menu, (unsigned int)originalMenu);
-		}
-		else {
-			// This case might happen if a menu was loaded and became an implicit override,
-			// but we didn't populate OverridenMenus with its original counterpart,
-			// or if it's a new menu being unloaded.
-			DebugPrint("PrepareToUnloadMenu: Unloading menu '{}' ({:X}). Not tracked as explicit override.", name, (unsigned int)menu);
-		}
+		bool isRemoval = OverridenMenus[name] == nullptr || !OverridenMenus.contains(name);
+		Game::menuDef_t* replacement = isRemoval ? nullptr : OverridenMenus[name];
 
 		for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
 		{
 			const auto context = Menus::GameUiContexts[contextIndex];
 
-			// 1. Remove the menu we are unloading from all contexts and stacks
-			RemoveMenuFromContext(context, menu);
-
-			// 2. If this menu was an override, attempt to put the original back
-			// This is critical for game-referenced menus like 'connect'.
-			if (originalMenu)
+			for (size_t i = 0; i < ARRAYSIZE(context->menuStack); i++)
 			{
-				bool foundExistingSpot = false;
-				// Check if original is already back (e.g., if another part of the game re-added it)
-				for (int i = 0; i < context->menuCount; ++i) {
-					if (context->Menus[i] == originalMenu) {
-						foundExistingSpot = true;
-						break;
+				if (context->menuStack[i] && context->menuStack[i]->window.name == name)
+				{
+					DebugPrint("In stack - Restored menu {} ({:X} => {:X})", name,
+						(unsigned int)context->menuStack[i],
+						(unsigned int)replacement
+					);
+
+					if (isRemoval)
+					{
+						if (context->menuStack[i] == menu)
+						{
+							context->menuStack[i] = replacement;
+
+							for (int j = static_cast<int>(i); j < context->openMenuCount - 1; j++)
+							{
+								context->menuStack[j] = context->menuStack[j + 1];
+							}
+
+							context->menuStack[context->openMenuCount] = nullptr;
+
+							context->openMenuCount--;
+							assert(context->openMenuCount >= 0);
+							i--;
+						}
+						else
+						{
+							// The menu I could have overriden got loaded in the meantime - no need to delete them
+							// I'm simply going to remove myself
+						}
+					}
+					else
+					{
+						context->menuStack[i] = replacement;
 					}
 				}
-				if (!foundExistingSpot) {
-					// Attempt to add the original menu back to the context's main array
-					if (context->menuCount < ARRAYSIZE(context->Menus)) {
-						context->Menus[context->menuCount] = originalMenu;
-						context->menuCount++;
-						DebugPrint("PrepareToUnloadMenu: Restored original menu '{}' ({:X}) to UI context {:X}.", name, (unsigned int)originalMenu, (unsigned int)context);
+			}
+
+			for (int i = 0; i < context->menuCount; i++)
+			{
+				if (context->Menus[i] && context->Menus[i]->window.name == name)
+				{
+					DebugPrint("In context - Restored menu {} ({:X} => {:X})", name,
+						(unsigned int)context->Menus[i],
+						(unsigned int)replacement
+					);
+
+					if (isRemoval)
+					{
+						if (context->Menus[i] == menu)
+						{
+							context->Menus[i] = replacement;
+
+							for (size_t j = i; j < std::min(static_cast<size_t>(context->menuCount), ARRAYSIZE(context->Menus)) - 1; j++)
+							{
+								context->Menus[j] = context->Menus[j + 1];
+							}
+
+							context->Menus[context->menuCount] = nullptr;
+
+							context->menuCount--;
+							i--;
+							assert(context->menuCount >= 0);
+						}
+						else
+						{
+							// The menu I could have overriden got loaded in the meantime - no need to delete them
+							// I'm simply going to remove myself
+						}
 					}
-					else {
-						Components::Logger::Print(Game::CON_CHANNEL_UI, "PrepareToUnloadMenu: UI context menu array full for restoring original menu {}\n", name);
+					else
+					{
+						context->Menus[i] = replacement;
 					}
 				}
 			}
 		}
 
-		// Clear the override tracking after processing.
-		if (OverridenMenus.count(name))
+		if (OverridenMenus.contains(name))
 		{
-			DebugPrint("PrepareToUnloadMenu: Clearing override tracking for menu '{}'.", name);
 			OverridenMenus.erase(name);
 		}
 	}
@@ -716,99 +705,80 @@ namespace Components
 	void Menus::AfterLoadedMenuFromDisk(Game::menuDef_t* menu)
 	{
 		const std::string name = menu->window.name;
-		DebugPrint("AfterLoadedMenuFromDisk: Loaded menu '{}' at {:X}.", name, (unsigned int)menu);
 
-		Game::menuDef_t* existingGameMenu = nullptr;
-		bool foundExistingInContext = false;
+		DebugPrint("Loaded menu {} at {:X} from disk", name,
+			(unsigned int)menu
+		);
 
-		// Check if a menu with the same name already exists in ANY of the game contexts.
-		// This identifies if our newly loaded menu is an override.
+		bool overrode = false;
+
 		for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
 		{
 			const auto context = Menus::GameUiContexts[contextIndex];
-			Game::menuDef_t* found = Game::Menus_FindByName(context, name.data());
-			if (found && found != menu) // Found an existing menu that is NOT our newly loaded one
+
+			for (size_t i = 0; i < ARRAYSIZE(context->menuStack); i++)
 			{
-				existingGameMenu = found;
-				foundExistingInContext = true;
-				DebugPrint("AfterLoadedMenuFromDisk: Found existing menu '{}' ({:X}) in context {:X}. This is an override.", name, (unsigned int)existingGameMenu, (unsigned int)context);
-				break; // Only need to find one existing instance to confirm it's an override
+				if (context->menuStack[i] && context->menuStack[i]->window.name == name)
+				{
+					if (OverridenMenus.contains(name))
+					{
+						assert(OverridenMenus[name] == context->menuStack[i]);
+					}
+					else
+					{
+						OverridenMenus[name] = context->menuStack[i];
+					}
+
+					context->menuStack[i] = MenusFromDisk[name];
+
+					DebugPrint("In stack - Overrode menu {} ({:X} => {:X})", name,
+						(unsigned int)OverridenMenus[name],
+						(unsigned int)MenusFromDisk[name]
+					);
+				}
+			}
+
+			for (int i = 0; i < context->menuCount; i++)
+			{
+				if (context->Menus[i] && context->Menus[i]->window.name == name)
+				{
+					if (OverridenMenus.contains(name))
+					{
+						assert(OverridenMenus[name] == context->Menus[i]);
+					}
+					else
+					{
+						OverridenMenus[name] = context->Menus[i];
+					}
+
+					context->Menus[i] = MenusFromDisk[name];
+
+					DebugPrint("In context - Overrode menu {} ({:X} => {:X})", name,
+						(unsigned int)OverridenMenus[name],
+						(unsigned int)MenusFromDisk[name]
+					);
+
+					overrode = true;
+				}
 			}
 		}
 
-		if (foundExistingInContext)
+		if (!overrode)
 		{
-			// This new menu is an override.
-			// 1. Store the original menu for later restoration if this custom menu is unloaded.
-			if (!OverridenMenus.count(name) || OverridenMenus[name] == nullptr) { // Only store if not already tracked or if previously tracked as nullptr
-				OverridenMenus[name] = existingGameMenu;
-				DebugPrint("AfterLoadedMenuFromDisk: Stored original menu '{}' ({:X}) for override by new menu ({:X}).", name, (unsigned int)existingGameMenu, (unsigned int)menu);
-			}
-
-			// 2. Remove all instances of the original menu from ALL contexts and their stacks.
-			// This is crucial to prevent the original from lingering.
-			for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
-			{
-				RemoveMenuFromContext(GameUiContexts[contextIndex], existingGameMenu);
-			}
-		}
-		else
-		{
-			// This is a brand new menu, not an override. Mark it as such.
-			// Ensure it's not present in OverridenMenus, or set to nullptr.
+			// A brand new menu! How fancy!
+			// We add it to the standard uiContext
 			OverridenMenus[name] = nullptr;
-			DebugPrint("AfterLoadedMenuFromDisk: Menu '{}' ({:X}) is a new menu, not an override.", name, (unsigned int)menu);
-		}
 
-		// Now, add the newly loaded custom menu to the main UI context (Game::uiContext).
-		// This applies to both new menus and overrides.
-		bool menuAlreadyActiveInUiContext = false;
-		for (int i = 0; i < Game::uiContext->menuCount; ++i) {
-			if (Game::uiContext->Menus[i] == menu) { // Check if our new menu instance is already there
-				menuAlreadyActiveInUiContext = true;
-				break;
-			}
-		}
-
-		if (!menuAlreadyActiveInUiContext) {
 			if (Game::uiContext->menuCount < ARRAYSIZE(Game::uiContext->Menus))
 			{
-				Game::uiContext->Menus[Game::uiContext->menuCount] = menu;
+				Game::uiContext->Menus[Game::uiContext->menuCount] = MenusFromDisk[name];
 				Game::uiContext->menuCount++;
-				DebugPrint("AfterLoadedMenuFromDisk: Added menu '{}' ({:X}) to Game::uiContext->Menus[{}] (Total count: {}).",
-					name, (unsigned int)menu, Game::uiContext->menuCount - 1, Game::uiContext->menuCount);
 			}
-			else {
-				Components::Logger::PrintError(Game::CON_CHANNEL_UI, "AfterLoadedMenuFromDisk: UI context menu array full for adding menu {}\n", name);
-			}
-		}
-		else {
-			DebugPrint("AfterLoadedMenuFromDisk: Menu '{}' ({:X}) already present in Game::uiContext->Menus, no re-addition.", name, (unsigned int)menu);
-		}
-
-		// Do NOT automatically add it to the menuStack here unless you're explicitly opening it.
-		// Opening a menu (e.g., via `open "menuName"`) is what typically pushes it to the stack.
-		// If you push it here and the game doesn't expect it, it can lead to stacking issues.
-		// The `Game::Menus_OpenByName` call usually handles pushing to the stack.
-		// The previous logic for `wasOverride && !menuAlreadyInStack` to add to stack is risky.
-		// Remove this block:
-		/*
-		bool menuAlreadyInStack = false;
-		for (int i = 0; i < Game::uiContext->openMenuCount; ++i) {
-			if (Game::uiContext->menuStack[i] == MenusFromDisk[name]) {
-				menuAlreadyInStack = true;
-				break;
+			else
+			{
+				Components::Logger::PrintError(Game::CON_CHANNEL_UI, "UI context menu array is full, could not add menu {}\n", name);
 			}
 		}
-		if (wasOverride && !menuAlreadyInStack) {
-			if (Game::uiContext->openMenuCount < ARRAYSIZE(Game::uiContext->menuStack)) {
-				Game::uiContext->menuStack[Game::uiContext->openMenuCount] = MenusFromDisk[name];
-				Game::uiContext->openMenuCount++;
-				DebugPrint("Added menu {} ({:X}) to Game::uiContext->menuStack[{}] (Total count: {})",
-					name, (unsigned int)MenusFromDisk[name], Game::uiContext->openMenuCount - 1, Game::uiContext->openMenuCount);
-			}
-		}
-		*/
 	}
 
 	void Menus::Add(const std::string& menu)
@@ -1393,7 +1363,6 @@ namespace Components
 		const auto menusFromDisk = MenusFromDisk;
 		for (const auto& element : menusFromDisk)
 		{
-			// IMPORTANT: Call UnloadMenuFromDisk which now uses RemoveMenuFromContext
 			UnloadMenuFromDisk(element.first);
 		}
 
@@ -1593,9 +1562,7 @@ namespace Components
 		Components::Events::OnCGameInit(ReloadDiskMenus_OnCGameStart);
 		Components::Events::AfterUIInit(ReloadDiskMenus_OnUIInitialization);
 
-		// --- HOOK ASSET HANDLER ---
-		// These hooks were present in your OLD working code.
-		// They are the key to intercepting asset lookup calls via AssetHandler.
+		// Keep disk-loaded menu overrides visible to direct asset lookups, including connect.menu.
 		AssetHandler::OnFind(Game::ASSET_TYPE_MENU, MenuFindHook);
 		AssetHandler::OnFind(Game::ASSET_TYPE_MENULIST, MenuListFindHook);
 
@@ -1621,14 +1588,14 @@ namespace Components
 				}
 			}, HOOK_CALL).install()->quick();
 
-		// Intercept menu painting (This hook was in old code)
+		// Intercept menu painting so a loaded custom connect menu wins over the stock one.
 		Utils::Hook(0x4FFBDF, IsMenuVisible, HOOK_CALL).install()->quick();
 
 		// disable the 2 new tokens in ItemParse_rect (Fix by NTA. Probably because he didn't want to update the menus)
 		Utils::Hook::Set<std::uint8_t>(0x640693, 0xEB);
 
-		// don't load ASSET_TYPE_MENU assets for every menu (might cause patch menus to fail) (This NOP was in old code)
-		Utils::Hook::Nop(0x453406, 5); // Re-added this NOP
+		// don't load ASSET_TYPE_MENU assets for every menu (might cause patch menus to fail).
+		Utils::Hook::Nop(0x453406, 5);
 
 		// make Com_Error and similar go back to main_text instead of menu_xboxlive.
 		Utils::Hook::SetString(0x6FC790, "main_text");
@@ -1693,7 +1660,7 @@ namespace Components
 		// The "reloadmenus" command from the old code is removed here as the new system's ReloadDiskMenus() handles it differently.
 		// Command::Add("reloadmenus", []() { ... });
 
-		// Define custom menus here (Keep this, as ReloadDiskMenus() still uses it)
+		// Define custom menus here. ReloadDiskMenus() loads these alongside discovered disk menus.
 		Add("ui_mp/changelog.menu");
 		Add("ui_mp/iw4x_credits.menu");
 		Add("ui_mp/menu_first_launch.menu");
@@ -1726,20 +1693,12 @@ namespace Components
 	}
 }
 
-// --- Implement AssetHandler hooks (from old Menus.cpp) ---
-// These will act as the new AssetHandler for menus, routing to your internal loaders.
+// Return disk-loaded menus to direct asset lookups, while falling back to stock assets when absent.
 namespace Components
 {
 	Game::XAssetHeader Menus::MenuFindHook(Game::XAssetType /*type*/, const std::string& filename)
 	{
-		// This hook needs to return YOUR loaded menu, if it exists in MenusFromDisk.
-		// Otherwise, it should call the original game function to find the asset.
-		// Since we don't have a direct "DB_FindXAssetHeader_Original" in this strategy,
-		// we rely on the game's default asset handler to load it if we don't have it.
-		// The ImenuDef_t::load function (which is part of the AssetHandler process)
-		// will handle loading from disk.
-
-		// Clean the name similar to DB_FindXAssetHeader_Hook logic in the previous attempt
+		// Asset requests can arrive as "connect", "connect.menu", or with a ui_mp path.
 		std::string shortName = filename;
 		size_t lastSlash = shortName.find_last_of("/\\");
 		if (lastSlash != std::string::npos) shortName = shortName.substr(lastSlash + 1);
@@ -1753,10 +1712,7 @@ namespace Components
 			return { MenusFromDisk[shortName] };
 		}
 
-		// If not found in our custom map, let the game's default DB_FindXAssetHeader handle it.
-		// The AssetHandler::IAsset::load implementation (e.g., in ImenuDef_t.cpp)
-		// will be responsible for loading the actual game asset or calling our LoadMenuByName_Recursive.
-		// Returning a nullptr XAssetHeader might force the AssetHandler to call the IAsset::load method.
+		// Returning nullptr lets the original DB_FindXAssetHeader path handle stock menus.
 		DebugPrint("MenuFindHook: Menu '{}' not found in custom list. Returning nullptr to trigger default AssetHandler load.", shortName);
 		return { nullptr };
 	}
@@ -1765,14 +1721,14 @@ namespace Components
 	{
 		(void)type;
 
-		// This hook needs to return YOUR loaded menulist, if it exists.
+		// Return a disk-loaded menu list when one was registered under the requested name.
 		if (MenuListsFromDisk.contains(filename))
 		{
 			DebugPrint("MenuListFindHook: Intercepted request for menulist '{}'. Returning custom menulist ({:X})", filename, (unsigned int)MenuListsFromDisk[filename]);
 			return { MenuListsFromDisk[filename] };
 		}
 
-		// If not found in our custom map, let the game's default DB_FindXAssetHeader handle it.
+		// Returning nullptr lets the original DB_FindXAssetHeader path handle stock menu lists.
 		DebugPrint("MenuListFindHook: Menulist '{}' not found in custom list. Returning nullptr to trigger default AssetHandler load.", filename);
 		return { nullptr };
 	}

--- a/src/Components/Modules/Menus.hpp
+++ b/src/Components/Modules/Menus.hpp
@@ -17,11 +17,8 @@ namespace Components
 
 		static bool IsMenuVisible(Game::UiContext* dc, Game::menuDef_t* menu);
 
-		static void RemoveMenuFromContext(Game::UiContext* dc, Game::menuDef_t* menuToRemove);
-
 		static Game::XAssetHeader MenuFindHook(Game::XAssetType type, const std::string& filename);
 		static Game::XAssetHeader MenuListFindHook(Game::XAssetType type, const std::string& filename);
-
 
 	private:
 		static std::unordered_map<std::string, Game::menuDef_t*> MenusFromDisk;


### PR DESCRIPTION
### Motivation

- Restore IW4x-style disk menu behavior so custom disk-loaded menus replace matching entries in UI contexts and stacks rather than being removed globally. 
- Ensure custom `connect.menu` and other IW4x-provided menus are discoverable by asset lookups and win over the stock menu when present. 
- Prevent leave-behind pointers and menu stacking issues when unloading overrides by restoring originals appropriately.

### Description

- Reworked override lifecycle: `AfterLoadedMenuFromDisk` now replaces matching entries in each `UiContext` and menu stack and records the original menu pointer in `OverridenMenus` for later restoration. 
- Reimplemented unload logic: `PrepareToUnloadMenu` now restores the original menu pointer (or compacts arrays when removing a custom menu) across all contexts and stacks, and removes override tracking. 
- Removed the now-unused public `RemoveMenuFromContext` declaration and its standalone implementation, consolidating replacement/removal logic into the IW4x-style flow. 
- Kept and clarified AssetHandler hooks by registering `MenuFindHook` and `MenuListFindHook` so disk-loaded menus (including `connect.menu`) are returned for direct asset lookups, falling back to the original asset path when absent, and updated comments/debug prints around these hooks and custom menu registration.

### Testing

- Ran `git diff --check` to validate whitespace and basic repository issues, which completed without errors. 
- Attempted build generation validation with `premake5 --version` but `premake5` is not installed in this environment so project generation/build tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318fd2223c832590d172cebcc55ca9)