### PR TITLE
Menus: robust disk menu overrides, ensure custom connect, and SP loadscreen improvements

### DIFF
--- a/src/Components/Modules/Maps.cpp
+++ b/src/Components/Modules/Maps.cpp
@@ -4,6 +4,7 @@
 #include "MemoryGuard.hpp"
 #include "RawFiles.hpp"
 #include "StartupMessages.hpp"
+#include "SPLoadscreens.hpp"
 #include "Theatre.hpp"
 
 namespace Components
@@ -446,6 +447,8 @@ namespace Components
 
 	void Maps::PrepareUsermap(const char* mapname)
 	{
+		SPLoadscreens::SetLoadingMap(mapname ? mapname : "");
+
 		// Handle the redundant call scenario first.
 		//
 		// It appears that this function is called a second time during fastfile

--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -41,6 +41,7 @@ namespace Components
 	Game::ExpressionSupportingData* Menus::SupportingData;
 
 	Utils::Memory::Allocator Menus::Allocator;
+	bool Menus::ShuttingDown = false;
 
 	Game::KeywordHashEntry<Game::menuDef_t, 128, 3523>** menuParseKeywordHash;
 
@@ -322,54 +323,6 @@ namespace Components
 		return menus;
 	}
 
-	// Add the RemoveMenuFromContext helper function (same as previous iteration)
-	void Menus::RemoveMenuFromContext(Game::UiContext* dc, Game::menuDef_t* menuToRemove)
-	{
-		if (!dc || !menuToRemove) return;
-
-		// Search for the menu in the context's main menu array
-		for (int i = 0; i < dc->menuCount; ++i)
-		{
-			if (dc->Menus[i] == menuToRemove)
-			{
-				DebugPrint("Removing menu {} from UI context {:X} at index {}",
-					menuToRemove->window.name, (unsigned int)dc, i);
-
-				// Shift elements left to fill the gap
-				for (int j = i; j < dc->menuCount - 1; ++j)
-				{
-					dc->Menus[j] = dc->Menus[j + 1];
-				}
-
-				// Clear the last element and decrement count
-				dc->Menus[--dc->menuCount] = nullptr;
-				// Adjust loop counter as we removed an element and shifted
-				i--;
-			}
-		}
-
-		// Also check and remove from the menu stack if present
-		for (int i = 0; i < dc->openMenuCount; ++i)
-		{
-			if (dc->menuStack[i] == menuToRemove)
-			{
-				DebugPrint("Removing menu {} from UI context {:X} stack at index {}",
-					menuToRemove->window.name, (unsigned int)dc, i);
-
-				// Shift elements left to fill the gap
-				for (int j = i; j < dc->openMenuCount - 1; ++j)
-				{
-					dc->menuStack[j] = dc->menuStack[j + 1];
-				}
-
-				// Clear the last element and decrement count
-				dc->menuStack[--dc->openMenuCount] = nullptr;
-				// Adjust loop counter as we removed an element and shifted
-				i--;
-			}
-		}
-	}
-
 
 	bool Menus::MenuAlreadyExists(const std::string& name)
 	{
@@ -382,6 +335,108 @@ namespace Components
 		}
 
 		return false;
+	}
+
+	bool Menus::IsCustomMenuPath(const std::string& menu)
+	{
+		std::string normalized = menu;
+		Utils::String::Replace(normalized, "/", "\\");
+
+		for (auto customMenu : CustomIW4xMenus)
+		{
+			Utils::String::Replace(customMenu, "/", "\\");
+			if (!_stricmp(customMenu.data(), normalized.data()))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	bool Menus::IsCustomMenuFile(const std::string& filename)
+	{
+		return IsCustomMenuPath(std::format("ui_mp\\{}", filename));
+	}
+
+	void Menus::EnsureCustomConnectMenu()
+	{
+		if (ShuttingDown)
+		{
+			return;
+		}
+
+		const auto customConnect = MenusFromDisk.contains("connect") ? MenusFromDisk["connect"] : nullptr;
+		if (!customConnect)
+		{
+			return;
+		}
+
+		for (const auto context : Menus::GameUiContexts)
+		{
+			if (!context)
+			{
+				continue;
+			}
+
+			for (int i = 0; i < context->openMenuCount; ++i)
+			{
+				if (context->menuStack[i] && context->menuStack[i]->window.name == "connect"s && context->menuStack[i] != customConnect)
+				{
+					DebugPrint("Replacing late stock connect menu in stack ({:X} => {:X})",
+						(unsigned int)context->menuStack[i], (unsigned int)customConnect);
+					context->menuStack[i] = customConnect;
+				}
+			}
+
+			bool hasCustomConnect = false;
+			for (int i = 0; i < context->menuCount; ++i)
+			{
+				if (context->Menus[i] == customConnect)
+				{
+					hasCustomConnect = true;
+				}
+				else if (context->Menus[i] && context->Menus[i]->window.name == "connect"s)
+				{
+					DebugPrint("Replacing late stock connect menu in context ({:X} => {:X})",
+						(unsigned int)context->Menus[i], (unsigned int)customConnect);
+					context->Menus[i] = customConnect;
+					hasCustomConnect = true;
+				}
+			}
+
+			if (!hasCustomConnect && context == Game::uiContext && context->menuCount < ARRAYSIZE(context->Menus))
+			{
+				context->Menus[context->menuCount++] = customConnect;
+			}
+		}
+	}
+
+	bool Menus::LoadCustomConnectMenu()
+	{
+		static bool isLoading = false;
+		if (ShuttingDown)
+		{
+			return false;
+		}
+
+		if (MenusFromDisk.contains("connect"))
+		{
+			EnsureCustomConnectMenu();
+			return true;
+		}
+
+		if (isLoading || !IsCustomMenuPath("ui_mp\\connect.menu"))
+		{
+			return false;
+		}
+
+		isLoading = true;
+		LoadScriptMenu("ui_mp\\connect.menu", true);
+		isLoading = false;
+
+		EnsureCustomConnectMenu();
+		return MenusFromDisk.contains("connect");
 	}
 
 	void Menus::LoadScriptMenu(const char* menu, bool allowNewMenus)
@@ -658,57 +713,97 @@ namespace Components
 	void Menus::PrepareToUnloadMenu(Game::menuDef_t* menu)
 	{
 		const std::string name = menu->window.name;
-		Game::menuDef_t* originalMenu = nullptr;
-
-		// Check if this menu was an override we previously tracked
-		if (OverridenMenus.count(name)) {
-			originalMenu = OverridenMenus[name]; // This could be nullptr if it was an implicit override of an unknown pointer
-			DebugPrint("PrepareToUnloadMenu: Unloading menu '{}' ({:X}). Original was tracked as {:X}.", name, (unsigned int)menu, (unsigned int)originalMenu);
-		}
-		else {
-			// This case might happen if a menu was loaded and became an implicit override,
-			// but we didn't populate OverridenMenus with its original counterpart,
-			// or if it's a new menu being unloaded.
-			DebugPrint("PrepareToUnloadMenu: Unloading menu '{}' ({:X}). Not tracked as explicit override.", name, (unsigned int)menu);
-		}
+		const auto overrideEntry = OverridenMenus.find(name);
+		const bool isRemoval = overrideEntry == OverridenMenus.end() || overrideEntry->second == nullptr;
+		Game::menuDef_t* replacement = isRemoval ? nullptr : overrideEntry->second;
 
 		for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
 		{
 			const auto context = Menus::GameUiContexts[contextIndex];
-
-			// 1. Remove the menu we are unloading from all contexts and stacks
-			RemoveMenuFromContext(context, menu);
-
-			// 2. If this menu was an override, attempt to put the original back
-			// This is critical for game-referenced menus like 'connect'.
-			if (originalMenu)
+			if (!context)
 			{
-				bool foundExistingSpot = false;
-				// Check if original is already back (e.g., if another part of the game re-added it)
-				for (int i = 0; i < context->menuCount; ++i) {
-					if (context->Menus[i] == originalMenu) {
-						foundExistingSpot = true;
-						break;
+				continue;
+			}
+
+			for (int i = 0; i < context->openMenuCount; i++)
+			{
+				if (context->menuStack[i] && context->menuStack[i]->window.name == name)
+				{
+					DebugPrint("In stack - Restored menu {} ({:X} => {:X})", name,
+						(unsigned int)context->menuStack[i],
+						(unsigned int)replacement
+					);
+
+					if (isRemoval)
+					{
+						if (context->menuStack[i] == menu)
+						{
+							context->menuStack[i] = replacement;
+
+							for (int j = static_cast<int>(i); j < context->openMenuCount - 1; j++)
+							{
+								context->menuStack[j] = context->menuStack[j + 1];
+							}
+
+							context->openMenuCount--;
+							assert(context->openMenuCount >= 0);
+							context->menuStack[context->openMenuCount] = nullptr;
+							i--;
+						}
+						else
+						{
+							// The menu I could have overriden got loaded in the meantime - no need to delete them
+							// I'm simply going to remove myself
+						}
+					}
+					else
+					{
+						context->menuStack[i] = replacement;
 					}
 				}
-				if (!foundExistingSpot) {
-					// Attempt to add the original menu back to the context's main array
-					if (context->menuCount < ARRAYSIZE(context->Menus)) {
-						context->Menus[context->menuCount] = originalMenu;
-						context->menuCount++;
-						DebugPrint("PrepareToUnloadMenu: Restored original menu '{}' ({:X}) to UI context {:X}.", name, (unsigned int)originalMenu, (unsigned int)context);
+			}
+
+			for (int i = 0; i < context->menuCount; i++)
+			{
+				if (context->Menus[i] && context->Menus[i]->window.name == name)
+				{
+					DebugPrint("In context - Restored menu {} ({:X} => {:X})", name,
+						(unsigned int)context->Menus[i],
+						(unsigned int)replacement
+					);
+
+					if (isRemoval)
+					{
+						if (context->Menus[i] == menu)
+						{
+							context->Menus[i] = replacement;
+
+							for (size_t j = i; j < std::min(static_cast<size_t>(context->menuCount), ARRAYSIZE(context->Menus)) - 1; j++)
+							{
+								context->Menus[j] = context->Menus[j + 1];
+							}
+
+							context->menuCount--;
+							i--;
+							assert(context->menuCount >= 0);
+							context->Menus[context->menuCount] = nullptr;
+						}
+						else
+						{
+							// The menu I could have overriden got loaded in the meantime - no need to delete them
+							// I'm simply going to remove myself
+						}
 					}
-					else {
-						Components::Logger::Print(Game::CON_CHANNEL_UI, "PrepareToUnloadMenu: UI context menu array full for restoring original menu {}\n", name);
+					else
+					{
+						context->Menus[i] = replacement;
 					}
 				}
 			}
 		}
 
-		// Clear the override tracking after processing.
-		if (OverridenMenus.count(name))
+		if (OverridenMenus.contains(name))
 		{
-			DebugPrint("PrepareToUnloadMenu: Clearing override tracking for menu '{}'.", name);
 			OverridenMenus.erase(name);
 		}
 	}
@@ -716,99 +811,84 @@ namespace Components
 	void Menus::AfterLoadedMenuFromDisk(Game::menuDef_t* menu)
 	{
 		const std::string name = menu->window.name;
-		DebugPrint("AfterLoadedMenuFromDisk: Loaded menu '{}' at {:X}.", name, (unsigned int)menu);
 
-		Game::menuDef_t* existingGameMenu = nullptr;
-		bool foundExistingInContext = false;
+		DebugPrint("Loaded menu {} at {:X} from disk", name,
+			(unsigned int)menu
+		);
 
-		// Check if a menu with the same name already exists in ANY of the game contexts.
-		// This identifies if our newly loaded menu is an override.
+		bool overrode = false;
+
 		for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
 		{
 			const auto context = Menus::GameUiContexts[contextIndex];
-			Game::menuDef_t* found = Game::Menus_FindByName(context, name.data());
-			if (found && found != menu) // Found an existing menu that is NOT our newly loaded one
+			if (!context)
 			{
-				existingGameMenu = found;
-				foundExistingInContext = true;
-				DebugPrint("AfterLoadedMenuFromDisk: Found existing menu '{}' ({:X}) in context {:X}. This is an override.", name, (unsigned int)existingGameMenu, (unsigned int)context);
-				break; // Only need to find one existing instance to confirm it's an override
+				continue;
+			}
+
+			for (int i = 0; i < context->openMenuCount; i++)
+			{
+				if (context->menuStack[i] && context->menuStack[i]->window.name == name)
+				{
+					if (OverridenMenus.contains(name))
+					{
+						assert(OverridenMenus[name] == context->menuStack[i]);
+					}
+					else
+					{
+						OverridenMenus[name] = context->menuStack[i];
+					}
+
+					context->menuStack[i] = MenusFromDisk[name];
+
+					DebugPrint("In stack - Overrode menu {} ({:X} => {:X})", name,
+						(unsigned int)OverridenMenus[name],
+						(unsigned int)MenusFromDisk[name]
+					);
+				}
+			}
+
+			for (int i = 0; i < context->menuCount; i++)
+			{
+				if (context->Menus[i] && context->Menus[i]->window.name == name)
+				{
+					if (OverridenMenus.contains(name))
+					{
+						assert(OverridenMenus[name] == context->Menus[i]);
+					}
+					else
+					{
+						OverridenMenus[name] = context->Menus[i];
+					}
+
+					context->Menus[i] = MenusFromDisk[name];
+
+					DebugPrint("In context - Overrode menu {} ({:X} => {:X})", name,
+						(unsigned int)OverridenMenus[name],
+						(unsigned int)MenusFromDisk[name]
+					);
+
+					overrode = true;
+				}
 			}
 		}
 
-		if (foundExistingInContext)
+		if (!overrode)
 		{
-			// This new menu is an override.
-			// 1. Store the original menu for later restoration if this custom menu is unloaded.
-			if (!OverridenMenus.count(name) || OverridenMenus[name] == nullptr) { // Only store if not already tracked or if previously tracked as nullptr
-				OverridenMenus[name] = existingGameMenu;
-				DebugPrint("AfterLoadedMenuFromDisk: Stored original menu '{}' ({:X}) for override by new menu ({:X}).", name, (unsigned int)existingGameMenu, (unsigned int)menu);
-			}
-
-			// 2. Remove all instances of the original menu from ALL contexts and their stacks.
-			// This is crucial to prevent the original from lingering.
-			for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
-			{
-				RemoveMenuFromContext(GameUiContexts[contextIndex], existingGameMenu);
-			}
-		}
-		else
-		{
-			// This is a brand new menu, not an override. Mark it as such.
-			// Ensure it's not present in OverridenMenus, or set to nullptr.
+			// A brand new menu! How fancy!
+			// We add it to the standard uiContext
 			OverridenMenus[name] = nullptr;
-			DebugPrint("AfterLoadedMenuFromDisk: Menu '{}' ({:X}) is a new menu, not an override.", name, (unsigned int)menu);
-		}
 
-		// Now, add the newly loaded custom menu to the main UI context (Game::uiContext).
-		// This applies to both new menus and overrides.
-		bool menuAlreadyActiveInUiContext = false;
-		for (int i = 0; i < Game::uiContext->menuCount; ++i) {
-			if (Game::uiContext->Menus[i] == menu) { // Check if our new menu instance is already there
-				menuAlreadyActiveInUiContext = true;
-				break;
-			}
-		}
-
-		if (!menuAlreadyActiveInUiContext) {
 			if (Game::uiContext->menuCount < ARRAYSIZE(Game::uiContext->Menus))
 			{
-				Game::uiContext->Menus[Game::uiContext->menuCount] = menu;
+				Game::uiContext->Menus[Game::uiContext->menuCount] = MenusFromDisk[name];
 				Game::uiContext->menuCount++;
-				DebugPrint("AfterLoadedMenuFromDisk: Added menu '{}' ({:X}) to Game::uiContext->Menus[{}] (Total count: {}).",
-					name, (unsigned int)menu, Game::uiContext->menuCount - 1, Game::uiContext->menuCount);
 			}
-			else {
-				Components::Logger::PrintError(Game::CON_CHANNEL_UI, "AfterLoadedMenuFromDisk: UI context menu array full for adding menu {}\n", name);
-			}
-		}
-		else {
-			DebugPrint("AfterLoadedMenuFromDisk: Menu '{}' ({:X}) already present in Game::uiContext->Menus, no re-addition.", name, (unsigned int)menu);
-		}
-
-		// Do NOT automatically add it to the menuStack here unless you're explicitly opening it.
-		// Opening a menu (e.g., via `open "menuName"`) is what typically pushes it to the stack.
-		// If you push it here and the game doesn't expect it, it can lead to stacking issues.
-		// The `Game::Menus_OpenByName` call usually handles pushing to the stack.
-		// The previous logic for `wasOverride && !menuAlreadyInStack` to add to stack is risky.
-		// Remove this block:
-		/*
-		bool menuAlreadyInStack = false;
-		for (int i = 0; i < Game::uiContext->openMenuCount; ++i) {
-			if (Game::uiContext->menuStack[i] == MenusFromDisk[name]) {
-				menuAlreadyInStack = true;
-				break;
+			else
+			{
+				Components::Logger::PrintError(Game::CON_CHANNEL_UI, "UI context menu array is full, could not add menu {}\n", name);
 			}
 		}
-		if (wasOverride && !menuAlreadyInStack) {
-			if (Game::uiContext->openMenuCount < ARRAYSIZE(Game::uiContext->menuStack)) {
-				Game::uiContext->menuStack[Game::uiContext->openMenuCount] = MenusFromDisk[name];
-				Game::uiContext->openMenuCount++;
-				DebugPrint("Added menu {} ({:X}) to Game::uiContext->menuStack[{}] (Total count: {})",
-					name, (unsigned int)MenusFromDisk[name], Game::uiContext->openMenuCount - 1, Game::uiContext->openMenuCount);
-			}
-		}
-		*/
 	}
 
 	void Menus::Add(const std::string& menu)
@@ -1393,7 +1473,6 @@ namespace Components
 		const auto menusFromDisk = MenusFromDisk;
 		for (const auto& element : menusFromDisk)
 		{
-			// IMPORTANT: Call UnloadMenuFromDisk which now uses RemoveMenuFromContext
 			UnloadMenuFromDisk(element.first);
 		}
 
@@ -1419,15 +1498,22 @@ namespace Components
 			OverridenMenus.clear();
 		}
 
-		// Step 2: Load everything
+		// Step 2: Load connect first so stock connect is never shown during level startup.
+		LoadCustomConnectMenu();
+
+		// Step 3: Load everything else
 		{
 			const auto menus = FileSystem::GetFileList("ui_mp", "menu", Game::FS_LIST_ALL);
 
 			// Load standalone menus
 			for (const auto& filename : menus)
 			{
-				const std::string fullPath = std::format("ui_mp\\{}", filename);
+				if (IsCustomMenuFile(filename))
+				{
+					continue;
+				}
 
+				const std::string fullPath = std::format("ui_mp\\{}", filename);
 				LoadScriptMenu(fullPath.c_str(), allowStrayMenus);
 			}
 
@@ -1458,11 +1544,19 @@ namespace Components
 			// "code.txt" for IW4x
 			for (const auto& menuName : CustomIW4xMenus)
 			{
+				auto normalizedMenuName = menuName;
+				Utils::String::Replace(normalizedMenuName, "/", "\\");
+				if (!_stricmp(normalizedMenuName.data(), "ui_mp\\connect.menu"))
+				{
+					continue;
+				}
+
 				LoadScriptMenu(menuName.c_str(), true);
 			}
 		}
 
-		// Step 3 - Keep supporting data around
+		// Step 4 - Keep supporting data around
+		EnsureCustomConnectMenu();
 
 		// Debug-only check
 		CheckMenus();
@@ -1470,6 +1564,11 @@ namespace Components
 
 	bool Menus::IsMenuVisible(Game::UiContext* dc, Game::menuDef_t* menu)
 	{
+		if (!ShuttingDown)
+		{
+			EnsureCustomConnectMenu();
+		}
+
 		if (menu && menu->window.name)
 		{
 			if (menu->window.name == "connect"s) // Check if we're supposed to draw the loadscreen
@@ -1593,9 +1692,7 @@ namespace Components
 		Components::Events::OnCGameInit(ReloadDiskMenus_OnCGameStart);
 		Components::Events::AfterUIInit(ReloadDiskMenus_OnUIInitialization);
 
-		// --- HOOK ASSET HANDLER ---
-		// These hooks were present in your OLD working code.
-		// They are the key to intercepting asset lookup calls via AssetHandler.
+		// Keep disk-loaded menu overrides visible to direct asset lookups, including connect.menu.
 		AssetHandler::OnFind(Game::ASSET_TYPE_MENU, MenuFindHook);
 		AssetHandler::OnFind(Game::ASSET_TYPE_MENULIST, MenuListFindHook);
 
@@ -1621,14 +1718,24 @@ namespace Components
 				}
 			}, HOOK_CALL).install()->quick();
 
-		// Intercept menu painting (This hook was in old code)
+		// Intercept menu painting so a loaded custom connect menu wins over the stock one.
 		Utils::Hook(0x4FFBDF, IsMenuVisible, HOOK_CALL).install()->quick();
+		Components::Scheduler::Schedule([]
+			{
+				if (ShuttingDown)
+				{
+					return true;
+				}
+
+				EnsureCustomConnectMenu();
+				return false;
+			}, Components::Scheduler::Pipeline::MAIN);
 
 		// disable the 2 new tokens in ItemParse_rect (Fix by NTA. Probably because he didn't want to update the menus)
 		Utils::Hook::Set<std::uint8_t>(0x640693, 0xEB);
 
-		// don't load ASSET_TYPE_MENU assets for every menu (might cause patch menus to fail) (This NOP was in old code)
-		Utils::Hook::Nop(0x453406, 5); // Re-added this NOP
+		// don't load ASSET_TYPE_MENU assets for every menu (might cause patch menus to fail).
+		Utils::Hook::Nop(0x453406, 5);
 
 		// make Com_Error and similar go back to main_text instead of menu_xboxlive.
 		Utils::Hook::SetString(0x6FC790, "main_text");
@@ -1693,7 +1800,7 @@ namespace Components
 		// The "reloadmenus" command from the old code is removed here as the new system's ReloadDiskMenus() handles it differently.
 		// Command::Add("reloadmenus", []() { ... });
 
-		// Define custom menus here (Keep this, as ReloadDiskMenus() still uses it)
+		// Define custom menus here. ReloadDiskMenus() loads these alongside discovered disk menus.
 		Add("ui_mp/changelog.menu");
 		Add("ui_mp/iw4x_credits.menu");
 		Add("ui_mp/menu_first_launch.menu");
@@ -1720,31 +1827,30 @@ namespace Components
 
 	void Menus::preDestroy()
 	{
+		ShuttingDown = true;
+
 		// Let Windows handle the memory leaks for you!
 		// The old code had Menus::FreeEverything(); here.
 		// If the new system handles freeing globally, this might not be needed.
 	}
 }
 
-// --- Implement AssetHandler hooks (from old Menus.cpp) ---
-// These will act as the new AssetHandler for menus, routing to your internal loaders.
+// Return disk-loaded menus to direct asset lookups, while falling back to stock assets when absent.
 namespace Components
 {
 	Game::XAssetHeader Menus::MenuFindHook(Game::XAssetType /*type*/, const std::string& filename)
 	{
-		// This hook needs to return YOUR loaded menu, if it exists in MenusFromDisk.
-		// Otherwise, it should call the original game function to find the asset.
-		// Since we don't have a direct "DB_FindXAssetHeader_Original" in this strategy,
-		// we rely on the game's default asset handler to load it if we don't have it.
-		// The ImenuDef_t::load function (which is part of the AssetHandler process)
-		// will handle loading from disk.
-
-		// Clean the name similar to DB_FindXAssetHeader_Hook logic in the previous attempt
+		// Asset requests can arrive as "connect", "connect.menu", or with a ui_mp path.
 		std::string shortName = filename;
 		size_t lastSlash = shortName.find_last_of("/\\");
 		if (lastSlash != std::string::npos) shortName = shortName.substr(lastSlash + 1);
 		if (shortName.length() > 5 && shortName.substr(shortName.length() - 5) == ".menu") {
 			shortName = shortName.substr(0, shortName.length() - 5);
+		}
+
+		if (!_stricmp(shortName.data(), "connect"))
+		{
+			LoadCustomConnectMenu();
 		}
 
 		if (MenusFromDisk.contains(shortName))
@@ -1753,10 +1859,7 @@ namespace Components
 			return { MenusFromDisk[shortName] };
 		}
 
-		// If not found in our custom map, let the game's default DB_FindXAssetHeader handle it.
-		// The AssetHandler::IAsset::load implementation (e.g., in ImenuDef_t.cpp)
-		// will be responsible for loading the actual game asset or calling our LoadMenuByName_Recursive.
-		// Returning a nullptr XAssetHeader might force the AssetHandler to call the IAsset::load method.
+		// Returning nullptr lets the original DB_FindXAssetHeader path handle stock menus.
 		DebugPrint("MenuFindHook: Menu '{}' not found in custom list. Returning nullptr to trigger default AssetHandler load.", shortName);
 		return { nullptr };
 	}
@@ -1765,14 +1868,14 @@ namespace Components
 	{
 		(void)type;
 
-		// This hook needs to return YOUR loaded menulist, if it exists.
+		// Return a disk-loaded menu list when one was registered under the requested name.
 		if (MenuListsFromDisk.contains(filename))
 		{
 			DebugPrint("MenuListFindHook: Intercepted request for menulist '{}'. Returning custom menulist ({:X})", filename, (unsigned int)MenuListsFromDisk[filename]);
 			return { MenuListsFromDisk[filename] };
 		}
 
-		// If not found in our custom map, let the game's default DB_FindXAssetHeader handle it.
+		// Returning nullptr lets the original DB_FindXAssetHeader path handle stock menu lists.
 		DebugPrint("MenuListFindHook: Menulist '{}' not found in custom list. Returning nullptr to trigger default AssetHandler load.", filename);
 		return { nullptr };
 	}

--- a/src/Components/Modules/Menus.hpp
+++ b/src/Components/Modules/Menus.hpp
@@ -17,11 +17,8 @@ namespace Components
 
 		static bool IsMenuVisible(Game::UiContext* dc, Game::menuDef_t* menu);
 
-		static void RemoveMenuFromContext(Game::UiContext* dc, Game::menuDef_t* menuToRemove);
-
 		static Game::XAssetHeader MenuFindHook(Game::XAssetType type, const std::string& filename);
 		static Game::XAssetHeader MenuListFindHook(Game::XAssetType type, const std::string& filename);
-
 
 	private:
 		static std::unordered_map<std::string, Game::menuDef_t*> MenusFromDisk;
@@ -38,8 +35,13 @@ namespace Components
 		static std::vector<std::string> CustomIW4xMenus;
 
 		static Utils::Memory::Allocator Allocator;
+		static bool ShuttingDown;
 
 		static bool MenuAlreadyExists(const std::string& name);
+		static bool IsCustomMenuPath(const std::string& menu);
+		static bool IsCustomMenuFile(const std::string& filename);
+		static void EnsureCustomConnectMenu();
+		static bool LoadCustomConnectMenu();
 
 		static void FreeZAllocatedMemory(const void* ptr, bool fromTheGame = false);
 		static void FreeAllocatedString(const void* ptr, bool fromTheGame = false);

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -5,54 +5,95 @@
 #include "STDInclude.hpp"
 
 namespace Components {
+	std::string SPLoadscreens::LoadingMap;
+
+	void SPLoadscreens::SetLoadingMap(const std::string& mapname)
+	{
+		LoadingMap = mapname;
+	}
+
 	SPLoadscreens::SPLoadscreens()
 	{
 		auto getPreviewImage = [](const std::string& materialName) -> Game::GfxImage*
 			{
-				std::string mapname = "";
+				auto findPreviewForMap = [](const std::string& mapname) -> Game::GfxImage*
+				{
+					if (mapname.empty() || Utils::String::StartsWith(mapname, "mp_"))
+					{
+						return nullptr;
+					}
+
+					std::vector<std::string> variants = { "preview_" + mapname };
+
+					if (mapname.find('_') != std::string::npos)
+					{
+						std::string simpleName = mapname;
+						Utils::String::Replace(simpleName, "_", "");
+						variants.push_back("preview_" + simpleName);
+					}
+
+					for (const auto& variant : variants)
+					{
+						if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
+						{
+							Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
+							if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
+							{
+								imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
+								AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
+							}
+							return imageHeader.image;
+						}
+					}
+
+					return nullptr;
+				};
+
 				if (Utils::String::StartsWith(materialName, "loadscreen_"))
 				{
-					mapname = materialName.substr(11);
-				}
-				else
-				{
-					// Fallback to current map dvar if it's a generic loadscreen material
-					Game::dvar_t* ui_mapname = Game::Dvar_FindVar("ui_mapname");
-					if (ui_mapname && ui_mapname->current.string)
+					const auto explicitMap = materialName.substr(11);
+					if (auto* image = findPreviewForMap(explicitMap))
 					{
-						mapname = ui_mapname->current.string;
+						LoadingMap = explicitMap;
+						return image;
 					}
 				}
 
-				if (mapname.empty()) return nullptr;
+				const auto* uiMapDvar = Game::Dvar_FindVar("ui_mapname");
+				const auto* mapDvar = Game::Dvar_FindVar("mapname");
+				const auto* uiMap = (uiMapDvar && uiMapDvar->current.string) ? uiMapDvar->current.string : "";
+				const auto* map = (mapDvar && mapDvar->current.string) ? mapDvar->current.string : "";
 
-				// If the map name starts with "mp_", we skip it entirely
-				if (Utils::String::StartsWith(mapname, "mp_"))
+				// When changing SP maps from the console, ui_mapname can point at the requested
+				// map while mapname still points at the currently running map. Prefer that
+				// transition target before the last explicit loadscreen material we saw.
+				if (*uiMap && _stricmp(uiMap, map))
 				{
-					return nullptr;
-				}
-
-				std::vector<std::string> variants = { "preview_" + mapname };
-
-				// Handle potential underscores
-				if (mapname.find('_') != std::string::npos)
-				{
-					std::string simpleName = mapname;
-					Utils::String::Replace(simpleName, "_", "");
-					variants.push_back("preview_" + simpleName);
-				}
-
-				for (const auto& variant : variants)
-				{
-					if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
+					if (auto* image = findPreviewForMap(uiMap))
 					{
-						Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
-						if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
+						return image;
+					}
+				}
+
+				if (!LoadingMap.empty())
+				{
+					if (auto* image = findPreviewForMap(LoadingMap))
+					{
+						return image;
+					}
+				}
+
+				// Generic loading materials are reused between SP maps. ui_mapname tends to be
+				// updated for the requested map before the read-only mapname dvar changes.
+				for (const auto* dvarName : { "ui_mapname", "mapname", "sv_mapname" })
+				{
+					Game::dvar_t* dvar = Game::Dvar_FindVar(dvarName);
+					if (dvar && dvar->current.string)
+					{
+						if (auto* image = findPreviewForMap(dvar->current.string))
 						{
-							imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
-							AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
+							return image;
 						}
-						return imageHeader.image;
 					}
 				}
 
@@ -64,15 +105,21 @@ namespace Components {
 				if (!material) return;
 
 				Game::GfxImage* image = getPreviewImage(name);
+				if (!image && material->info.name)
+				{
+					image = getPreviewImage(material->info.name);
+				}
+
 				if (image && !strstr(image->name, "default"))
 				{
 					for (int i = 0; i < material->textureCount; ++i)
 					{
 						if (material->textureTable[i].u.image)
 						{
-							bool isDefault = strstr(material->textureTable[i].u.image->name, "default") != nullptr;
-							bool isOldPreview = strstr(material->textureTable[i].u.image->name, "preview_") != nullptr &&
-								strstr(material->textureTable[i].u.image->name, image->name) == nullptr;
+							const auto* currentName = material->textureTable[i].u.image->name ? material->textureTable[i].u.image->name : "";
+							const bool isDefault = strstr(currentName, "default") != nullptr;
+							const bool isOldPreview = strstr(currentName, "preview_") != nullptr && strstr(currentName, image->name) == nullptr;
+
 							if (isDefault || (isOldPreview && isElementExplicit))
 							{
 								material->textureTable[i].u.image = image;
@@ -100,26 +147,16 @@ namespace Components {
 				return { nullptr };
 			});
 
-		AssetHandler::OnLoad([getPreviewImage](Game::XAssetType type, Game::XAssetHeader asset, const std::string& name, bool*)
+		AssetHandler::OnLoad([patchMaterial](Game::XAssetType type, Game::XAssetHeader asset, const std::string& name, bool*)
 			{
 				if (type == Game::ASSET_TYPE_MATERIAL && (Utils::String::Contains(name, "loadscreen") || name == "loading_image"))
 				{
-					Game::GfxImage* image = getPreviewImage(name);
-					if (image && !strstr(image->name, "default"))
-					{
-						for (int i = 0; i < asset.material->textureCount; ++i)
-						{
-							if (asset.material->textureTable[i].u.image && strstr(asset.material->textureTable[i].u.image->name, "default"))
-							{
-								asset.material->textureTable[i].u.image = image;
-							}
-						}
-					}
+					patchMaterial(asset.material, name, true);
 				}
 			});
 
 		// Active monitoring for the connect menu
-		Scheduler::Loop([getPreviewImage, patchMaterial]()
+		Scheduler::Loop([patchMaterial]()
 			{
 				Game::menuDef_t* connectMenu = Game::Menus_FindByName(Game::uiContext, "connect");
 				if (connectMenu && Game::Menu_IsVisible(Game::uiContext, connectMenu))
@@ -137,14 +174,17 @@ namespace Components {
 							if (item->window.name)
 							{
 								std::string winName = item->window.name;
-								if (Utils::String::Contains(winName, "loadscreen") || Utils::String::Contains(winName, "preview"))
-								{
-									isExplicitTarget = true;
-								}
+								isExplicitTarget = Utils::String::Contains(winName, "loadscreen") || Utils::String::Contains(winName, "preview");
 							}
 							else
 							{
 								isExplicitTarget = true;
+							}
+
+							if (!isExplicitTarget && item->window.background && item->window.background->info.name)
+							{
+								isExplicitTarget = Utils::String::Contains(item->window.background->info.name, "loadscreen") ||
+									Utils::String::Contains(item->window.background->info.name, "preview");
 							}
 
 							patchMaterial(item->window.background, item->window.name ? item->window.name : "level_loadscreen", isExplicitTarget);

--- a/src/Components/Modules/SPLoadscreens.hpp
+++ b/src/Components/Modules/SPLoadscreens.hpp
@@ -7,5 +7,10 @@ namespace Components
 	public:
 		SPLoadscreens();
 		~SPLoadscreens();
+
+		static void SetLoadingMap(const std::string& mapname);
+
+	private:
+		static std::string LoadingMap;
 	};
 }


### PR DESCRIPTION
### Motivation
- Ensure disk-loaded menus can reliably override and replace stock menus (particularly `connect.menu`) so the stock connect UI is not shown during startup.
- Make menu override lifecycle safer by tracking and restoring original menu pointers without leaving stale references or causing double-free issues during unload/shutdown.
- Improve single-player loadscreen preview selection so explicit map previews are used consistently and preview images can be found for mapped variants.

### Description
- Add menu lifecycle helpers and state: `Menus::ShuttingDown`, `IsCustomMenuPath`, `IsCustomMenuFile`, `EnsureCustomConnectMenu`, and `LoadCustomConnectMenu`, and call `ShuttingDown` in `preDestroy` to avoid races at shutdown.
- Rework override handling by removing `RemoveMenuFromContext` and rewriting `PrepareToUnloadMenu` and `AfterLoadedMenuFromDisk` to reliably store originals in `OverridenMenus`, replace instances with disk-loaded menus from `MenusFromDisk`, and erase tracking when appropriate.
- Ensure the custom `connect.menu` is loaded early in `ReloadDiskMenus`, skip duplicate custom menu files, and schedule `EnsureCustomConnectMenu` on the main pipeline so the custom connect always takes precedence over stock during startup.
- Hook asset lookup via `MenuFindHook` and `MenuListFindHook` so disk-loaded menus/menulists are returned to the game's asset system, and trigger `LoadCustomConnectMenu` on connect lookups.
- Add `SPLoadscreens::LoadingMap` and `SetLoadingMap`, call it from `Maps::PrepareUsermap`, and overhaul preview image lookup and material patching to prefer explicit map preview variants, handle underscore variants, and patch connect menu backgrounds.
- Minor API and housekeeping updates such as header include additions, scheduling a `EnsureCustomConnectMenu` task, and adjusting error/debug logging paths.

### Testing
- Built the project in both Debug and Release configurations successfully with no compile errors.
- Ran the project's automated unit/integration test suite and observed all tests pass (no new test failures introduced).
- Executed automated smoke tests for menu reload and SP loadscreen flows which validated that the custom `connect.menu` replaces the stock menu and that SP loadscreen preview images are selected and applied without regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318fd2223c832590d172cebcc55ca9)