### PR TITLE
Menus: reliable disk-loaded menu overrides, custom connect handling, and SP loadscreen improvements

### DIFF
--- a/src/Components/Modules/Maps.cpp
+++ b/src/Components/Modules/Maps.cpp
@@ -4,7 +4,6 @@
 #include "MemoryGuard.hpp"
 #include "RawFiles.hpp"
 #include "StartupMessages.hpp"
-#include "SPLoadscreens.hpp"
 #include "Theatre.hpp"
 
 namespace Components
@@ -447,7 +446,10 @@ namespace Components
 
 	void Maps::PrepareUsermap(const char* mapname)
 	{
-		SPLoadscreens::SetLoadingMap(mapname ? mapname : "");
+		if (mapname && *Game::ui_mapname && !Utils::String::StartsWith(mapname, "mp_"))
+		{
+			Game::Dvar_SetString(*Game::ui_mapname, mapname);
+		}
 
 		// Handle the redundant call scenario first.
 		//

--- a/src/Components/Modules/Maps.cpp
+++ b/src/Components/Modules/Maps.cpp
@@ -4,6 +4,7 @@
 #include "MemoryGuard.hpp"
 #include "RawFiles.hpp"
 #include "StartupMessages.hpp"
+#include "SPLoadscreens.hpp"
 #include "Theatre.hpp"
 
 namespace Components
@@ -449,6 +450,7 @@ namespace Components
 		if (mapname && *Game::ui_mapname && !Utils::String::StartsWith(mapname, "mp_"))
 		{
 			Game::Dvar_SetString(*Game::ui_mapname, mapname);
+			SPLoadscreens::PreloadMapPreview(mapname);
 		}
 
 		// Handle the redundant call scenario first.

--- a/src/Components/Modules/Maps.cpp
+++ b/src/Components/Modules/Maps.cpp
@@ -4,6 +4,7 @@
 #include "MemoryGuard.hpp"
 #include "RawFiles.hpp"
 #include "StartupMessages.hpp"
+#include "SPLoadscreens.hpp"
 #include "Theatre.hpp"
 
 namespace Components
@@ -446,6 +447,8 @@ namespace Components
 
 	void Maps::PrepareUsermap(const char* mapname)
 	{
+		SPLoadscreens::SetLoadingMap(mapname ? mapname : "");
+
 		// Handle the redundant call scenario first.
 		//
 		// It appears that this function is called a second time during fastfile

--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -1408,7 +1408,12 @@ namespace Components
 		if (MenusFromDisk.contains(menuName)) {
 			const auto menu = MenusFromDisk[menuName];
 			PrepareToUnloadMenu(menu);
-			FreeMenuOnly(menu);
+
+			// Menu trees contain game-owned and allocator-owned nested pointers that are
+			// still referenced by UI/cgame paths during disconnect and shutdown. Trying
+			// to deep-free them here can hang or corrupt those paths, so mirror the
+			// component shutdown policy and intentionally leak disk-loaded menus for the
+			// process lifetime after detaching them from all contexts.
 			MenusFromDisk.erase(menuName);
 		}
 	}

--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -384,6 +384,26 @@ namespace Components
 		return false;
 	}
 
+	void Menus::AddMenuAlias(const std::string& source, const std::string& alias)
+	{
+		if (MenuAlreadyExists(alias))
+		{
+			return;
+		}
+
+		auto* sourceMenu = Game::Menus_FindByName(Game::uiContext, source.data());
+		if (!sourceMenu || Game::uiContext->menuCount >= ARRAYSIZE(Game::uiContext->Menus))
+		{
+			return;
+		}
+
+		auto* aliasMenu = Allocator.allocate<Game::menuDef_t>();
+		std::memcpy(aliasMenu, sourceMenu, sizeof(Game::menuDef_t));
+		aliasMenu->window.name = Allocator.duplicateString(alias);
+
+		Game::uiContext->Menus[Game::uiContext->menuCount++] = aliasMenu;
+	}
+
 	void Menus::LoadScriptMenu(const char* menu, bool allowNewMenus)
 	{
 		auto menus = LoadMenuByName_Recursive(menu);
@@ -1463,6 +1483,8 @@ namespace Components
 		}
 
 		// Step 3 - Keep supporting data around
+		AddMenuAlias("main_text", "menu_xboxlive_lobbyended");
+		AddMenuAlias("main_text", "menu_xboxlive_partyended");
 
 		// Debug-only check
 		CheckMenus();

--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -41,6 +41,8 @@ namespace Components
 	Game::ExpressionSupportingData* Menus::SupportingData;
 
 	Utils::Memory::Allocator Menus::Allocator;
+	bool Menus::ShuttingDown = false;
+	bool Menus::ReloadingMenus = false;
 
 	Game::KeywordHashEntry<Game::menuDef_t, 128, 3523>** menuParseKeywordHash;
 
@@ -322,54 +324,6 @@ namespace Components
 		return menus;
 	}
 
-	// Add the RemoveMenuFromContext helper function (same as previous iteration)
-	void Menus::RemoveMenuFromContext(Game::UiContext* dc, Game::menuDef_t* menuToRemove)
-	{
-		if (!dc || !menuToRemove) return;
-
-		// Search for the menu in the context's main menu array
-		for (int i = 0; i < dc->menuCount; ++i)
-		{
-			if (dc->Menus[i] == menuToRemove)
-			{
-				DebugPrint("Removing menu {} from UI context {:X} at index {}",
-					menuToRemove->window.name, (unsigned int)dc, i);
-
-				// Shift elements left to fill the gap
-				for (int j = i; j < dc->menuCount - 1; ++j)
-				{
-					dc->Menus[j] = dc->Menus[j + 1];
-				}
-
-				// Clear the last element and decrement count
-				dc->Menus[--dc->menuCount] = nullptr;
-				// Adjust loop counter as we removed an element and shifted
-				i--;
-			}
-		}
-
-		// Also check and remove from the menu stack if present
-		for (int i = 0; i < dc->openMenuCount; ++i)
-		{
-			if (dc->menuStack[i] == menuToRemove)
-			{
-				DebugPrint("Removing menu {} from UI context {:X} stack at index {}",
-					menuToRemove->window.name, (unsigned int)dc, i);
-
-				// Shift elements left to fill the gap
-				for (int j = i; j < dc->openMenuCount - 1; ++j)
-				{
-					dc->menuStack[j] = dc->menuStack[j + 1];
-				}
-
-				// Clear the last element and decrement count
-				dc->menuStack[--dc->openMenuCount] = nullptr;
-				// Adjust loop counter as we removed an element and shifted
-				i--;
-			}
-		}
-	}
-
 
 	bool Menus::MenuAlreadyExists(const std::string& name)
 	{
@@ -382,6 +336,108 @@ namespace Components
 		}
 
 		return false;
+	}
+
+	bool Menus::IsCustomMenuPath(const std::string& menu)
+	{
+		std::string normalized = menu;
+		Utils::String::Replace(normalized, "/", "\\");
+
+		for (auto customMenu : CustomIW4xMenus)
+		{
+			Utils::String::Replace(customMenu, "/", "\\");
+			if (!_stricmp(customMenu.data(), normalized.data()))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	bool Menus::IsCustomMenuFile(const std::string& filename)
+	{
+		return IsCustomMenuPath(std::format("ui_mp\\{}", filename));
+	}
+
+	void Menus::EnsureCustomConnectMenu()
+	{
+		if (ShuttingDown || ReloadingMenus)
+		{
+			return;
+		}
+
+		const auto customConnect = MenusFromDisk.contains("connect") ? MenusFromDisk["connect"] : nullptr;
+		if (!customConnect)
+		{
+			return;
+		}
+
+		for (const auto context : Menus::GameUiContexts)
+		{
+			if (!context)
+			{
+				continue;
+			}
+
+			for (int i = 0; i < context->openMenuCount; ++i)
+			{
+				if (context->menuStack[i] && context->menuStack[i]->window.name == "connect"s && context->menuStack[i] != customConnect)
+				{
+					DebugPrint("Replacing late stock connect menu in stack ({:X} => {:X})",
+						(unsigned int)context->menuStack[i], (unsigned int)customConnect);
+					context->menuStack[i] = customConnect;
+				}
+			}
+
+			bool hasCustomConnect = false;
+			for (int i = 0; i < context->menuCount; ++i)
+			{
+				if (context->Menus[i] == customConnect)
+				{
+					hasCustomConnect = true;
+				}
+				else if (context->Menus[i] && context->Menus[i]->window.name == "connect"s)
+				{
+					DebugPrint("Replacing late stock connect menu in context ({:X} => {:X})",
+						(unsigned int)context->Menus[i], (unsigned int)customConnect);
+					context->Menus[i] = customConnect;
+					hasCustomConnect = true;
+				}
+			}
+
+			if (!hasCustomConnect && context == Game::uiContext && context->menuCount < ARRAYSIZE(context->Menus))
+			{
+				context->Menus[context->menuCount++] = customConnect;
+			}
+		}
+	}
+
+	bool Menus::LoadCustomConnectMenu()
+	{
+		static bool isLoading = false;
+		if (ShuttingDown || ReloadingMenus)
+		{
+			return false;
+		}
+
+		if (MenusFromDisk.contains("connect"))
+		{
+			EnsureCustomConnectMenu();
+			return true;
+		}
+
+		if (isLoading || !IsCustomMenuPath("ui_mp\\connect.menu"))
+		{
+			return false;
+		}
+
+		isLoading = true;
+		LoadScriptMenu("ui_mp\\connect.menu", true);
+		isLoading = false;
+
+		EnsureCustomConnectMenu();
+		return MenusFromDisk.contains("connect");
 	}
 
 	void Menus::LoadScriptMenu(const char* menu, bool allowNewMenus)
@@ -658,57 +714,97 @@ namespace Components
 	void Menus::PrepareToUnloadMenu(Game::menuDef_t* menu)
 	{
 		const std::string name = menu->window.name;
-		Game::menuDef_t* originalMenu = nullptr;
-
-		// Check if this menu was an override we previously tracked
-		if (OverridenMenus.count(name)) {
-			originalMenu = OverridenMenus[name]; // This could be nullptr if it was an implicit override of an unknown pointer
-			DebugPrint("PrepareToUnloadMenu: Unloading menu '{}' ({:X}). Original was tracked as {:X}.", name, (unsigned int)menu, (unsigned int)originalMenu);
-		}
-		else {
-			// This case might happen if a menu was loaded and became an implicit override,
-			// but we didn't populate OverridenMenus with its original counterpart,
-			// or if it's a new menu being unloaded.
-			DebugPrint("PrepareToUnloadMenu: Unloading menu '{}' ({:X}). Not tracked as explicit override.", name, (unsigned int)menu);
-		}
+		const auto overrideEntry = OverridenMenus.find(name);
+		const bool isRemoval = overrideEntry == OverridenMenus.end() || overrideEntry->second == nullptr;
+		Game::menuDef_t* replacement = isRemoval ? nullptr : overrideEntry->second;
 
 		for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
 		{
 			const auto context = Menus::GameUiContexts[contextIndex];
-
-			// 1. Remove the menu we are unloading from all contexts and stacks
-			RemoveMenuFromContext(context, menu);
-
-			// 2. If this menu was an override, attempt to put the original back
-			// This is critical for game-referenced menus like 'connect'.
-			if (originalMenu)
+			if (!context)
 			{
-				bool foundExistingSpot = false;
-				// Check if original is already back (e.g., if another part of the game re-added it)
-				for (int i = 0; i < context->menuCount; ++i) {
-					if (context->Menus[i] == originalMenu) {
-						foundExistingSpot = true;
-						break;
+				continue;
+			}
+
+			for (int i = 0; i < context->openMenuCount; i++)
+			{
+				if (context->menuStack[i] && context->menuStack[i]->window.name == name)
+				{
+					DebugPrint("In stack - Restored menu {} ({:X} => {:X})", name,
+						(unsigned int)context->menuStack[i],
+						(unsigned int)replacement
+					);
+
+					if (isRemoval)
+					{
+						if (context->menuStack[i] == menu)
+						{
+							context->menuStack[i] = replacement;
+
+							for (int j = static_cast<int>(i); j < context->openMenuCount - 1; j++)
+							{
+								context->menuStack[j] = context->menuStack[j + 1];
+							}
+
+							context->openMenuCount--;
+							assert(context->openMenuCount >= 0);
+							context->menuStack[context->openMenuCount] = nullptr;
+							i--;
+						}
+						else
+						{
+							// The menu I could have overriden got loaded in the meantime - no need to delete them
+							// I'm simply going to remove myself
+						}
+					}
+					else
+					{
+						context->menuStack[i] = replacement;
 					}
 				}
-				if (!foundExistingSpot) {
-					// Attempt to add the original menu back to the context's main array
-					if (context->menuCount < ARRAYSIZE(context->Menus)) {
-						context->Menus[context->menuCount] = originalMenu;
-						context->menuCount++;
-						DebugPrint("PrepareToUnloadMenu: Restored original menu '{}' ({:X}) to UI context {:X}.", name, (unsigned int)originalMenu, (unsigned int)context);
+			}
+
+			for (int i = 0; i < context->menuCount; i++)
+			{
+				if (context->Menus[i] && context->Menus[i]->window.name == name)
+				{
+					DebugPrint("In context - Restored menu {} ({:X} => {:X})", name,
+						(unsigned int)context->Menus[i],
+						(unsigned int)replacement
+					);
+
+					if (isRemoval)
+					{
+						if (context->Menus[i] == menu)
+						{
+							context->Menus[i] = replacement;
+
+							for (size_t j = i; j < std::min(static_cast<size_t>(context->menuCount), ARRAYSIZE(context->Menus)) - 1; j++)
+							{
+								context->Menus[j] = context->Menus[j + 1];
+							}
+
+							context->menuCount--;
+							i--;
+							assert(context->menuCount >= 0);
+							context->Menus[context->menuCount] = nullptr;
+						}
+						else
+						{
+							// The menu I could have overriden got loaded in the meantime - no need to delete them
+							// I'm simply going to remove myself
+						}
 					}
-					else {
-						Components::Logger::Print(Game::CON_CHANNEL_UI, "PrepareToUnloadMenu: UI context menu array full for restoring original menu {}\n", name);
+					else
+					{
+						context->Menus[i] = replacement;
 					}
 				}
 			}
 		}
 
-		// Clear the override tracking after processing.
-		if (OverridenMenus.count(name))
+		if (OverridenMenus.contains(name))
 		{
-			DebugPrint("PrepareToUnloadMenu: Clearing override tracking for menu '{}'.", name);
 			OverridenMenus.erase(name);
 		}
 	}
@@ -716,99 +812,84 @@ namespace Components
 	void Menus::AfterLoadedMenuFromDisk(Game::menuDef_t* menu)
 	{
 		const std::string name = menu->window.name;
-		DebugPrint("AfterLoadedMenuFromDisk: Loaded menu '{}' at {:X}.", name, (unsigned int)menu);
 
-		Game::menuDef_t* existingGameMenu = nullptr;
-		bool foundExistingInContext = false;
+		DebugPrint("Loaded menu {} at {:X} from disk", name,
+			(unsigned int)menu
+		);
 
-		// Check if a menu with the same name already exists in ANY of the game contexts.
-		// This identifies if our newly loaded menu is an override.
+		bool overrode = false;
+
 		for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
 		{
 			const auto context = Menus::GameUiContexts[contextIndex];
-			Game::menuDef_t* found = Game::Menus_FindByName(context, name.data());
-			if (found && found != menu) // Found an existing menu that is NOT our newly loaded one
+			if (!context)
 			{
-				existingGameMenu = found;
-				foundExistingInContext = true;
-				DebugPrint("AfterLoadedMenuFromDisk: Found existing menu '{}' ({:X}) in context {:X}. This is an override.", name, (unsigned int)existingGameMenu, (unsigned int)context);
-				break; // Only need to find one existing instance to confirm it's an override
+				continue;
+			}
+
+			for (int i = 0; i < context->openMenuCount; i++)
+			{
+				if (context->menuStack[i] && context->menuStack[i]->window.name == name)
+				{
+					if (OverridenMenus.contains(name))
+					{
+						assert(OverridenMenus[name] == context->menuStack[i]);
+					}
+					else
+					{
+						OverridenMenus[name] = context->menuStack[i];
+					}
+
+					context->menuStack[i] = MenusFromDisk[name];
+
+					DebugPrint("In stack - Overrode menu {} ({:X} => {:X})", name,
+						(unsigned int)OverridenMenus[name],
+						(unsigned int)MenusFromDisk[name]
+					);
+				}
+			}
+
+			for (int i = 0; i < context->menuCount; i++)
+			{
+				if (context->Menus[i] && context->Menus[i]->window.name == name)
+				{
+					if (OverridenMenus.contains(name))
+					{
+						assert(OverridenMenus[name] == context->Menus[i]);
+					}
+					else
+					{
+						OverridenMenus[name] = context->Menus[i];
+					}
+
+					context->Menus[i] = MenusFromDisk[name];
+
+					DebugPrint("In context - Overrode menu {} ({:X} => {:X})", name,
+						(unsigned int)OverridenMenus[name],
+						(unsigned int)MenusFromDisk[name]
+					);
+
+					overrode = true;
+				}
 			}
 		}
 
-		if (foundExistingInContext)
+		if (!overrode)
 		{
-			// This new menu is an override.
-			// 1. Store the original menu for later restoration if this custom menu is unloaded.
-			if (!OverridenMenus.count(name) || OverridenMenus[name] == nullptr) { // Only store if not already tracked or if previously tracked as nullptr
-				OverridenMenus[name] = existingGameMenu;
-				DebugPrint("AfterLoadedMenuFromDisk: Stored original menu '{}' ({:X}) for override by new menu ({:X}).", name, (unsigned int)existingGameMenu, (unsigned int)menu);
-			}
-
-			// 2. Remove all instances of the original menu from ALL contexts and their stacks.
-			// This is crucial to prevent the original from lingering.
-			for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
-			{
-				RemoveMenuFromContext(GameUiContexts[contextIndex], existingGameMenu);
-			}
-		}
-		else
-		{
-			// This is a brand new menu, not an override. Mark it as such.
-			// Ensure it's not present in OverridenMenus, or set to nullptr.
+			// A brand new menu! How fancy!
+			// We add it to the standard uiContext
 			OverridenMenus[name] = nullptr;
-			DebugPrint("AfterLoadedMenuFromDisk: Menu '{}' ({:X}) is a new menu, not an override.", name, (unsigned int)menu);
-		}
 
-		// Now, add the newly loaded custom menu to the main UI context (Game::uiContext).
-		// This applies to both new menus and overrides.
-		bool menuAlreadyActiveInUiContext = false;
-		for (int i = 0; i < Game::uiContext->menuCount; ++i) {
-			if (Game::uiContext->Menus[i] == menu) { // Check if our new menu instance is already there
-				menuAlreadyActiveInUiContext = true;
-				break;
-			}
-		}
-
-		if (!menuAlreadyActiveInUiContext) {
 			if (Game::uiContext->menuCount < ARRAYSIZE(Game::uiContext->Menus))
 			{
-				Game::uiContext->Menus[Game::uiContext->menuCount] = menu;
+				Game::uiContext->Menus[Game::uiContext->menuCount] = MenusFromDisk[name];
 				Game::uiContext->menuCount++;
-				DebugPrint("AfterLoadedMenuFromDisk: Added menu '{}' ({:X}) to Game::uiContext->Menus[{}] (Total count: {}).",
-					name, (unsigned int)menu, Game::uiContext->menuCount - 1, Game::uiContext->menuCount);
 			}
-			else {
-				Components::Logger::PrintError(Game::CON_CHANNEL_UI, "AfterLoadedMenuFromDisk: UI context menu array full for adding menu {}\n", name);
-			}
-		}
-		else {
-			DebugPrint("AfterLoadedMenuFromDisk: Menu '{}' ({:X}) already present in Game::uiContext->Menus, no re-addition.", name, (unsigned int)menu);
-		}
-
-		// Do NOT automatically add it to the menuStack here unless you're explicitly opening it.
-		// Opening a menu (e.g., via `open "menuName"`) is what typically pushes it to the stack.
-		// If you push it here and the game doesn't expect it, it can lead to stacking issues.
-		// The `Game::Menus_OpenByName` call usually handles pushing to the stack.
-		// The previous logic for `wasOverride && !menuAlreadyInStack` to add to stack is risky.
-		// Remove this block:
-		/*
-		bool menuAlreadyInStack = false;
-		for (int i = 0; i < Game::uiContext->openMenuCount; ++i) {
-			if (Game::uiContext->menuStack[i] == MenusFromDisk[name]) {
-				menuAlreadyInStack = true;
-				break;
+			else
+			{
+				Components::Logger::PrintError(Game::CON_CHANNEL_UI, "UI context menu array is full, could not add menu {}\n", name);
 			}
 		}
-		if (wasOverride && !menuAlreadyInStack) {
-			if (Game::uiContext->openMenuCount < ARRAYSIZE(Game::uiContext->menuStack)) {
-				Game::uiContext->menuStack[Game::uiContext->openMenuCount] = MenusFromDisk[name];
-				Game::uiContext->openMenuCount++;
-				DebugPrint("Added menu {} ({:X}) to Game::uiContext->menuStack[{}] (Total count: {})",
-					name, (unsigned int)MenusFromDisk[name], Game::uiContext->openMenuCount - 1, Game::uiContext->openMenuCount);
-			}
-		}
-		*/
 	}
 
 	void Menus::Add(const std::string& menu)
@@ -1383,6 +1464,8 @@ namespace Components
 		DebugPrint("Reloading disk menus...");
 
 		// Step 1: unload everything
+		ReloadingMenus = true;
+
 		const auto listsFromDisk = MenuListsFromDisk;
 		for (const auto& menuList : listsFromDisk)
 		{
@@ -1393,7 +1476,6 @@ namespace Components
 		const auto menusFromDisk = MenusFromDisk;
 		for (const auto& element : menusFromDisk)
 		{
-			// IMPORTANT: Call UnloadMenuFromDisk which now uses RemoveMenuFromContext
 			UnloadMenuFromDisk(element.first);
 		}
 
@@ -1419,15 +1501,24 @@ namespace Components
 			OverridenMenus.clear();
 		}
 
-		// Step 2: Load everything
+		ReloadingMenus = false;
+
+		// Step 2: Load connect first so stock connect is never shown during level startup.
+		LoadCustomConnectMenu();
+
+		// Step 3: Load everything else
 		{
 			const auto menus = FileSystem::GetFileList("ui_mp", "menu", Game::FS_LIST_ALL);
 
 			// Load standalone menus
 			for (const auto& filename : menus)
 			{
-				const std::string fullPath = std::format("ui_mp\\{}", filename);
+				if (IsCustomMenuFile(filename))
+				{
+					continue;
+				}
 
+				const std::string fullPath = std::format("ui_mp\\{}", filename);
 				LoadScriptMenu(fullPath.c_str(), allowStrayMenus);
 			}
 
@@ -1458,11 +1549,19 @@ namespace Components
 			// "code.txt" for IW4x
 			for (const auto& menuName : CustomIW4xMenus)
 			{
+				auto normalizedMenuName = menuName;
+				Utils::String::Replace(normalizedMenuName, "/", "\\");
+				if (!_stricmp(normalizedMenuName.data(), "ui_mp\\connect.menu"))
+				{
+					continue;
+				}
+
 				LoadScriptMenu(menuName.c_str(), true);
 			}
 		}
 
-		// Step 3 - Keep supporting data around
+		// Step 4 - Keep supporting data around
+		EnsureCustomConnectMenu();
 
 		// Debug-only check
 		CheckMenus();
@@ -1470,6 +1569,11 @@ namespace Components
 
 	bool Menus::IsMenuVisible(Game::UiContext* dc, Game::menuDef_t* menu)
 	{
+		if (!ShuttingDown && !ReloadingMenus)
+		{
+			EnsureCustomConnectMenu();
+		}
+
 		if (menu && menu->window.name)
 		{
 			if (menu->window.name == "connect"s) // Check if we're supposed to draw the loadscreen
@@ -1593,9 +1697,7 @@ namespace Components
 		Components::Events::OnCGameInit(ReloadDiskMenus_OnCGameStart);
 		Components::Events::AfterUIInit(ReloadDiskMenus_OnUIInitialization);
 
-		// --- HOOK ASSET HANDLER ---
-		// These hooks were present in your OLD working code.
-		// They are the key to intercepting asset lookup calls via AssetHandler.
+		// Keep disk-loaded menu overrides visible to direct asset lookups, including connect.menu.
 		AssetHandler::OnFind(Game::ASSET_TYPE_MENU, MenuFindHook);
 		AssetHandler::OnFind(Game::ASSET_TYPE_MENULIST, MenuListFindHook);
 
@@ -1621,14 +1723,24 @@ namespace Components
 				}
 			}, HOOK_CALL).install()->quick();
 
-		// Intercept menu painting (This hook was in old code)
+		// Intercept menu painting so a loaded custom connect menu wins over the stock one.
 		Utils::Hook(0x4FFBDF, IsMenuVisible, HOOK_CALL).install()->quick();
+		Components::Scheduler::Schedule([]
+			{
+				if (ShuttingDown)
+				{
+					return true;
+				}
+
+				EnsureCustomConnectMenu();
+				return false;
+			}, Components::Scheduler::Pipeline::MAIN);
 
 		// disable the 2 new tokens in ItemParse_rect (Fix by NTA. Probably because he didn't want to update the menus)
 		Utils::Hook::Set<std::uint8_t>(0x640693, 0xEB);
 
-		// don't load ASSET_TYPE_MENU assets for every menu (might cause patch menus to fail) (This NOP was in old code)
-		Utils::Hook::Nop(0x453406, 5); // Re-added this NOP
+		// don't load ASSET_TYPE_MENU assets for every menu (might cause patch menus to fail).
+		Utils::Hook::Nop(0x453406, 5);
 
 		// make Com_Error and similar go back to main_text instead of menu_xboxlive.
 		Utils::Hook::SetString(0x6FC790, "main_text");
@@ -1693,7 +1805,7 @@ namespace Components
 		// The "reloadmenus" command from the old code is removed here as the new system's ReloadDiskMenus() handles it differently.
 		// Command::Add("reloadmenus", []() { ... });
 
-		// Define custom menus here (Keep this, as ReloadDiskMenus() still uses it)
+		// Define custom menus here. ReloadDiskMenus() loads these alongside discovered disk menus.
 		Add("ui_mp/changelog.menu");
 		Add("ui_mp/iw4x_credits.menu");
 		Add("ui_mp/menu_first_launch.menu");
@@ -1720,31 +1832,30 @@ namespace Components
 
 	void Menus::preDestroy()
 	{
+		ShuttingDown = true;
+
 		// Let Windows handle the memory leaks for you!
 		// The old code had Menus::FreeEverything(); here.
 		// If the new system handles freeing globally, this might not be needed.
 	}
 }
 
-// --- Implement AssetHandler hooks (from old Menus.cpp) ---
-// These will act as the new AssetHandler for menus, routing to your internal loaders.
+// Return disk-loaded menus to direct asset lookups, while falling back to stock assets when absent.
 namespace Components
 {
 	Game::XAssetHeader Menus::MenuFindHook(Game::XAssetType /*type*/, const std::string& filename)
 	{
-		// This hook needs to return YOUR loaded menu, if it exists in MenusFromDisk.
-		// Otherwise, it should call the original game function to find the asset.
-		// Since we don't have a direct "DB_FindXAssetHeader_Original" in this strategy,
-		// we rely on the game's default asset handler to load it if we don't have it.
-		// The ImenuDef_t::load function (which is part of the AssetHandler process)
-		// will handle loading from disk.
-
-		// Clean the name similar to DB_FindXAssetHeader_Hook logic in the previous attempt
+		// Asset requests can arrive as "connect", "connect.menu", or with a ui_mp path.
 		std::string shortName = filename;
 		size_t lastSlash = shortName.find_last_of("/\\");
 		if (lastSlash != std::string::npos) shortName = shortName.substr(lastSlash + 1);
 		if (shortName.length() > 5 && shortName.substr(shortName.length() - 5) == ".menu") {
 			shortName = shortName.substr(0, shortName.length() - 5);
+		}
+
+		if (!_stricmp(shortName.data(), "connect"))
+		{
+			LoadCustomConnectMenu();
 		}
 
 		if (MenusFromDisk.contains(shortName))
@@ -1753,10 +1864,7 @@ namespace Components
 			return { MenusFromDisk[shortName] };
 		}
 
-		// If not found in our custom map, let the game's default DB_FindXAssetHeader handle it.
-		// The AssetHandler::IAsset::load implementation (e.g., in ImenuDef_t.cpp)
-		// will be responsible for loading the actual game asset or calling our LoadMenuByName_Recursive.
-		// Returning a nullptr XAssetHeader might force the AssetHandler to call the IAsset::load method.
+		// Returning nullptr lets the original DB_FindXAssetHeader path handle stock menus.
 		DebugPrint("MenuFindHook: Menu '{}' not found in custom list. Returning nullptr to trigger default AssetHandler load.", shortName);
 		return { nullptr };
 	}
@@ -1765,14 +1873,14 @@ namespace Components
 	{
 		(void)type;
 
-		// This hook needs to return YOUR loaded menulist, if it exists.
+		// Return a disk-loaded menu list when one was registered under the requested name.
 		if (MenuListsFromDisk.contains(filename))
 		{
 			DebugPrint("MenuListFindHook: Intercepted request for menulist '{}'. Returning custom menulist ({:X})", filename, (unsigned int)MenuListsFromDisk[filename]);
 			return { MenuListsFromDisk[filename] };
 		}
 
-		// If not found in our custom map, let the game's default DB_FindXAssetHeader handle it.
+		// Returning nullptr lets the original DB_FindXAssetHeader path handle stock menu lists.
 		DebugPrint("MenuListFindHook: Menulist '{}' not found in custom list. Returning nullptr to trigger default AssetHandler load.", filename);
 		return { nullptr };
 	}

--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -1798,6 +1798,11 @@ namespace Components
 				}
 
 				const char* menuName = params->get(1);
+				if (!Game::Menus_FindByName(Game::uiContext, menuName) && !_strnicmp(menuName, "menu_xboxlive_", 13))
+				{
+					Logger::Print("Menu {} is unavailable, falling back to main_text\n", menuName);
+					menuName = "main_text";
+				}
 
 				Game::Menus_OpenByName(Game::uiContext, menuName);
 			});

--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -41,8 +41,6 @@ namespace Components
 	Game::ExpressionSupportingData* Menus::SupportingData;
 
 	Utils::Memory::Allocator Menus::Allocator;
-	bool Menus::ShuttingDown = false;
-	bool Menus::ReloadingMenus = false;
 
 	Game::KeywordHashEntry<Game::menuDef_t, 128, 3523>** menuParseKeywordHash;
 
@@ -324,6 +322,54 @@ namespace Components
 		return menus;
 	}
 
+	// Add the RemoveMenuFromContext helper function (same as previous iteration)
+	void Menus::RemoveMenuFromContext(Game::UiContext* dc, Game::menuDef_t* menuToRemove)
+	{
+		if (!dc || !menuToRemove) return;
+
+		// Search for the menu in the context's main menu array
+		for (int i = 0; i < dc->menuCount; ++i)
+		{
+			if (dc->Menus[i] == menuToRemove)
+			{
+				DebugPrint("Removing menu {} from UI context {:X} at index {}",
+					menuToRemove->window.name, (unsigned int)dc, i);
+
+				// Shift elements left to fill the gap
+				for (int j = i; j < dc->menuCount - 1; ++j)
+				{
+					dc->Menus[j] = dc->Menus[j + 1];
+				}
+
+				// Clear the last element and decrement count
+				dc->Menus[--dc->menuCount] = nullptr;
+				// Adjust loop counter as we removed an element and shifted
+				i--;
+			}
+		}
+
+		// Also check and remove from the menu stack if present
+		for (int i = 0; i < dc->openMenuCount; ++i)
+		{
+			if (dc->menuStack[i] == menuToRemove)
+			{
+				DebugPrint("Removing menu {} from UI context {:X} stack at index {}",
+					menuToRemove->window.name, (unsigned int)dc, i);
+
+				// Shift elements left to fill the gap
+				for (int j = i; j < dc->openMenuCount - 1; ++j)
+				{
+					dc->menuStack[j] = dc->menuStack[j + 1];
+				}
+
+				// Clear the last element and decrement count
+				dc->menuStack[--dc->openMenuCount] = nullptr;
+				// Adjust loop counter as we removed an element and shifted
+				i--;
+			}
+		}
+	}
+
 
 	bool Menus::MenuAlreadyExists(const std::string& name)
 	{
@@ -336,108 +382,6 @@ namespace Components
 		}
 
 		return false;
-	}
-
-	bool Menus::IsCustomMenuPath(const std::string& menu)
-	{
-		std::string normalized = menu;
-		Utils::String::Replace(normalized, "/", "\\");
-
-		for (auto customMenu : CustomIW4xMenus)
-		{
-			Utils::String::Replace(customMenu, "/", "\\");
-			if (!_stricmp(customMenu.data(), normalized.data()))
-			{
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	bool Menus::IsCustomMenuFile(const std::string& filename)
-	{
-		return IsCustomMenuPath(std::format("ui_mp\\{}", filename));
-	}
-
-	void Menus::EnsureCustomConnectMenu()
-	{
-		if (ShuttingDown || ReloadingMenus)
-		{
-			return;
-		}
-
-		const auto customConnect = MenusFromDisk.contains("connect") ? MenusFromDisk["connect"] : nullptr;
-		if (!customConnect)
-		{
-			return;
-		}
-
-		for (const auto context : Menus::GameUiContexts)
-		{
-			if (!context)
-			{
-				continue;
-			}
-
-			for (int i = 0; i < context->openMenuCount; ++i)
-			{
-				if (context->menuStack[i] && context->menuStack[i]->window.name == "connect"s && context->menuStack[i] != customConnect)
-				{
-					DebugPrint("Replacing late stock connect menu in stack ({:X} => {:X})",
-						(unsigned int)context->menuStack[i], (unsigned int)customConnect);
-					context->menuStack[i] = customConnect;
-				}
-			}
-
-			bool hasCustomConnect = false;
-			for (int i = 0; i < context->menuCount; ++i)
-			{
-				if (context->Menus[i] == customConnect)
-				{
-					hasCustomConnect = true;
-				}
-				else if (context->Menus[i] && context->Menus[i]->window.name == "connect"s)
-				{
-					DebugPrint("Replacing late stock connect menu in context ({:X} => {:X})",
-						(unsigned int)context->Menus[i], (unsigned int)customConnect);
-					context->Menus[i] = customConnect;
-					hasCustomConnect = true;
-				}
-			}
-
-			if (!hasCustomConnect && context == Game::uiContext && context->menuCount < ARRAYSIZE(context->Menus))
-			{
-				context->Menus[context->menuCount++] = customConnect;
-			}
-		}
-	}
-
-	bool Menus::LoadCustomConnectMenu()
-	{
-		static bool isLoading = false;
-		if (ShuttingDown || ReloadingMenus)
-		{
-			return false;
-		}
-
-		if (MenusFromDisk.contains("connect"))
-		{
-			EnsureCustomConnectMenu();
-			return true;
-		}
-
-		if (isLoading || !IsCustomMenuPath("ui_mp\\connect.menu"))
-		{
-			return false;
-		}
-
-		isLoading = true;
-		LoadScriptMenu("ui_mp\\connect.menu", true);
-		isLoading = false;
-
-		EnsureCustomConnectMenu();
-		return MenusFromDisk.contains("connect");
 	}
 
 	void Menus::LoadScriptMenu(const char* menu, bool allowNewMenus)
@@ -714,97 +658,57 @@ namespace Components
 	void Menus::PrepareToUnloadMenu(Game::menuDef_t* menu)
 	{
 		const std::string name = menu->window.name;
-		const auto overrideEntry = OverridenMenus.find(name);
-		const bool isRemoval = overrideEntry == OverridenMenus.end() || overrideEntry->second == nullptr;
-		Game::menuDef_t* replacement = isRemoval ? nullptr : overrideEntry->second;
+		Game::menuDef_t* originalMenu = nullptr;
+
+		// Check if this menu was an override we previously tracked
+		if (OverridenMenus.count(name)) {
+			originalMenu = OverridenMenus[name]; // This could be nullptr if it was an implicit override of an unknown pointer
+			DebugPrint("PrepareToUnloadMenu: Unloading menu '{}' ({:X}). Original was tracked as {:X}.", name, (unsigned int)menu, (unsigned int)originalMenu);
+		}
+		else {
+			// This case might happen if a menu was loaded and became an implicit override,
+			// but we didn't populate OverridenMenus with its original counterpart,
+			// or if it's a new menu being unloaded.
+			DebugPrint("PrepareToUnloadMenu: Unloading menu '{}' ({:X}). Not tracked as explicit override.", name, (unsigned int)menu);
+		}
 
 		for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
 		{
 			const auto context = Menus::GameUiContexts[contextIndex];
-			if (!context)
+
+			// 1. Remove the menu we are unloading from all contexts and stacks
+			RemoveMenuFromContext(context, menu);
+
+			// 2. If this menu was an override, attempt to put the original back
+			// This is critical for game-referenced menus like 'connect'.
+			if (originalMenu)
 			{
-				continue;
-			}
-
-			for (int i = 0; i < context->openMenuCount; i++)
-			{
-				if (context->menuStack[i] && context->menuStack[i]->window.name == name)
-				{
-					DebugPrint("In stack - Restored menu {} ({:X} => {:X})", name,
-						(unsigned int)context->menuStack[i],
-						(unsigned int)replacement
-					);
-
-					if (isRemoval)
-					{
-						if (context->menuStack[i] == menu)
-						{
-							context->menuStack[i] = replacement;
-
-							for (int j = static_cast<int>(i); j < context->openMenuCount - 1; j++)
-							{
-								context->menuStack[j] = context->menuStack[j + 1];
-							}
-
-							context->openMenuCount--;
-							assert(context->openMenuCount >= 0);
-							context->menuStack[context->openMenuCount] = nullptr;
-							i--;
-						}
-						else
-						{
-							// The menu I could have overriden got loaded in the meantime - no need to delete them
-							// I'm simply going to remove myself
-						}
-					}
-					else
-					{
-						context->menuStack[i] = replacement;
+				bool foundExistingSpot = false;
+				// Check if original is already back (e.g., if another part of the game re-added it)
+				for (int i = 0; i < context->menuCount; ++i) {
+					if (context->Menus[i] == originalMenu) {
+						foundExistingSpot = true;
+						break;
 					}
 				}
-			}
-
-			for (int i = 0; i < context->menuCount; i++)
-			{
-				if (context->Menus[i] && context->Menus[i]->window.name == name)
-				{
-					DebugPrint("In context - Restored menu {} ({:X} => {:X})", name,
-						(unsigned int)context->Menus[i],
-						(unsigned int)replacement
-					);
-
-					if (isRemoval)
-					{
-						if (context->Menus[i] == menu)
-						{
-							context->Menus[i] = replacement;
-
-							for (size_t j = i; j < std::min(static_cast<size_t>(context->menuCount), ARRAYSIZE(context->Menus)) - 1; j++)
-							{
-								context->Menus[j] = context->Menus[j + 1];
-							}
-
-							context->menuCount--;
-							i--;
-							assert(context->menuCount >= 0);
-							context->Menus[context->menuCount] = nullptr;
-						}
-						else
-						{
-							// The menu I could have overriden got loaded in the meantime - no need to delete them
-							// I'm simply going to remove myself
-						}
+				if (!foundExistingSpot) {
+					// Attempt to add the original menu back to the context's main array
+					if (context->menuCount < ARRAYSIZE(context->Menus)) {
+						context->Menus[context->menuCount] = originalMenu;
+						context->menuCount++;
+						DebugPrint("PrepareToUnloadMenu: Restored original menu '{}' ({:X}) to UI context {:X}.", name, (unsigned int)originalMenu, (unsigned int)context);
 					}
-					else
-					{
-						context->Menus[i] = replacement;
+					else {
+						Components::Logger::Print(Game::CON_CHANNEL_UI, "PrepareToUnloadMenu: UI context menu array full for restoring original menu {}\n", name);
 					}
 				}
 			}
 		}
 
-		if (OverridenMenus.contains(name))
+		// Clear the override tracking after processing.
+		if (OverridenMenus.count(name))
 		{
+			DebugPrint("PrepareToUnloadMenu: Clearing override tracking for menu '{}'.", name);
 			OverridenMenus.erase(name);
 		}
 	}
@@ -812,84 +716,99 @@ namespace Components
 	void Menus::AfterLoadedMenuFromDisk(Game::menuDef_t* menu)
 	{
 		const std::string name = menu->window.name;
+		DebugPrint("AfterLoadedMenuFromDisk: Loaded menu '{}' at {:X}.", name, (unsigned int)menu);
 
-		DebugPrint("Loaded menu {} at {:X} from disk", name,
-			(unsigned int)menu
-		);
+		Game::menuDef_t* existingGameMenu = nullptr;
+		bool foundExistingInContext = false;
 
-		bool overrode = false;
-
+		// Check if a menu with the same name already exists in ANY of the game contexts.
+		// This identifies if our newly loaded menu is an override.
 		for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
 		{
 			const auto context = Menus::GameUiContexts[contextIndex];
-			if (!context)
+			Game::menuDef_t* found = Game::Menus_FindByName(context, name.data());
+			if (found && found != menu) // Found an existing menu that is NOT our newly loaded one
 			{
-				continue;
-			}
-
-			for (int i = 0; i < context->openMenuCount; i++)
-			{
-				if (context->menuStack[i] && context->menuStack[i]->window.name == name)
-				{
-					if (OverridenMenus.contains(name))
-					{
-						assert(OverridenMenus[name] == context->menuStack[i]);
-					}
-					else
-					{
-						OverridenMenus[name] = context->menuStack[i];
-					}
-
-					context->menuStack[i] = MenusFromDisk[name];
-
-					DebugPrint("In stack - Overrode menu {} ({:X} => {:X})", name,
-						(unsigned int)OverridenMenus[name],
-						(unsigned int)MenusFromDisk[name]
-					);
-				}
-			}
-
-			for (int i = 0; i < context->menuCount; i++)
-			{
-				if (context->Menus[i] && context->Menus[i]->window.name == name)
-				{
-					if (OverridenMenus.contains(name))
-					{
-						assert(OverridenMenus[name] == context->Menus[i]);
-					}
-					else
-					{
-						OverridenMenus[name] = context->Menus[i];
-					}
-
-					context->Menus[i] = MenusFromDisk[name];
-
-					DebugPrint("In context - Overrode menu {} ({:X} => {:X})", name,
-						(unsigned int)OverridenMenus[name],
-						(unsigned int)MenusFromDisk[name]
-					);
-
-					overrode = true;
-				}
+				existingGameMenu = found;
+				foundExistingInContext = true;
+				DebugPrint("AfterLoadedMenuFromDisk: Found existing menu '{}' ({:X}) in context {:X}. This is an override.", name, (unsigned int)existingGameMenu, (unsigned int)context);
+				break; // Only need to find one existing instance to confirm it's an override
 			}
 		}
 
-		if (!overrode)
+		if (foundExistingInContext)
 		{
-			// A brand new menu! How fancy!
-			// We add it to the standard uiContext
-			OverridenMenus[name] = nullptr;
+			// This new menu is an override.
+			// 1. Store the original menu for later restoration if this custom menu is unloaded.
+			if (!OverridenMenus.count(name) || OverridenMenus[name] == nullptr) { // Only store if not already tracked or if previously tracked as nullptr
+				OverridenMenus[name] = existingGameMenu;
+				DebugPrint("AfterLoadedMenuFromDisk: Stored original menu '{}' ({:X}) for override by new menu ({:X}).", name, (unsigned int)existingGameMenu, (unsigned int)menu);
+			}
 
+			// 2. Remove all instances of the original menu from ALL contexts and their stacks.
+			// This is crucial to prevent the original from lingering.
+			for (size_t contextIndex = 0; contextIndex < ARRAYSIZE(Menus::GameUiContexts); contextIndex++)
+			{
+				RemoveMenuFromContext(GameUiContexts[contextIndex], existingGameMenu);
+			}
+		}
+		else
+		{
+			// This is a brand new menu, not an override. Mark it as such.
+			// Ensure it's not present in OverridenMenus, or set to nullptr.
+			OverridenMenus[name] = nullptr;
+			DebugPrint("AfterLoadedMenuFromDisk: Menu '{}' ({:X}) is a new menu, not an override.", name, (unsigned int)menu);
+		}
+
+		// Now, add the newly loaded custom menu to the main UI context (Game::uiContext).
+		// This applies to both new menus and overrides.
+		bool menuAlreadyActiveInUiContext = false;
+		for (int i = 0; i < Game::uiContext->menuCount; ++i) {
+			if (Game::uiContext->Menus[i] == menu) { // Check if our new menu instance is already there
+				menuAlreadyActiveInUiContext = true;
+				break;
+			}
+		}
+
+		if (!menuAlreadyActiveInUiContext) {
 			if (Game::uiContext->menuCount < ARRAYSIZE(Game::uiContext->Menus))
 			{
-				Game::uiContext->Menus[Game::uiContext->menuCount] = MenusFromDisk[name];
+				Game::uiContext->Menus[Game::uiContext->menuCount] = menu;
 				Game::uiContext->menuCount++;
+				DebugPrint("AfterLoadedMenuFromDisk: Added menu '{}' ({:X}) to Game::uiContext->Menus[{}] (Total count: {}).",
+					name, (unsigned int)menu, Game::uiContext->menuCount - 1, Game::uiContext->menuCount);
 			}
-			else
-			{
-				Components::Logger::PrintError(Game::CON_CHANNEL_UI, "UI context menu array is full, could not add menu {}\n", name);
+			else {
+				Components::Logger::PrintError(Game::CON_CHANNEL_UI, "AfterLoadedMenuFromDisk: UI context menu array full for adding menu {}\n", name);
 			}
 		}
+		else {
+			DebugPrint("AfterLoadedMenuFromDisk: Menu '{}' ({:X}) already present in Game::uiContext->Menus, no re-addition.", name, (unsigned int)menu);
+		}
+
+		// Do NOT automatically add it to the menuStack here unless you're explicitly opening it.
+		// Opening a menu (e.g., via `open "menuName"`) is what typically pushes it to the stack.
+		// If you push it here and the game doesn't expect it, it can lead to stacking issues.
+		// The `Game::Menus_OpenByName` call usually handles pushing to the stack.
+		// The previous logic for `wasOverride && !menuAlreadyInStack` to add to stack is risky.
+		// Remove this block:
+		/*
+		bool menuAlreadyInStack = false;
+		for (int i = 0; i < Game::uiContext->openMenuCount; ++i) {
+			if (Game::uiContext->menuStack[i] == MenusFromDisk[name]) {
+				menuAlreadyInStack = true;
+				break;
+			}
+		}
+		if (wasOverride && !menuAlreadyInStack) {
+			if (Game::uiContext->openMenuCount < ARRAYSIZE(Game::uiContext->menuStack)) {
+				Game::uiContext->menuStack[Game::uiContext->openMenuCount] = MenusFromDisk[name];
+				Game::uiContext->openMenuCount++;
+				DebugPrint("Added menu {} ({:X}) to Game::uiContext->menuStack[{}] (Total count: {})",
+					name, (unsigned int)MenusFromDisk[name], Game::uiContext->openMenuCount - 1, Game::uiContext->openMenuCount);
+			}
+		}
+		*/
 	}
 
 	void Menus::Add(const std::string& menu)
@@ -1408,12 +1327,7 @@ namespace Components
 		if (MenusFromDisk.contains(menuName)) {
 			const auto menu = MenusFromDisk[menuName];
 			PrepareToUnloadMenu(menu);
-
-			// Menu trees contain game-owned and allocator-owned nested pointers that are
-			// still referenced by UI/cgame paths during disconnect and shutdown. Trying
-			// to deep-free them here can hang or corrupt those paths, so mirror the
-			// component shutdown policy and intentionally leak disk-loaded menus for the
-			// process lifetime after detaching them from all contexts.
+			FreeMenuOnly(menu);
 			MenusFromDisk.erase(menuName);
 		}
 	}
@@ -1469,8 +1383,6 @@ namespace Components
 		DebugPrint("Reloading disk menus...");
 
 		// Step 1: unload everything
-		ReloadingMenus = true;
-
 		const auto listsFromDisk = MenuListsFromDisk;
 		for (const auto& menuList : listsFromDisk)
 		{
@@ -1481,6 +1393,7 @@ namespace Components
 		const auto menusFromDisk = MenusFromDisk;
 		for (const auto& element : menusFromDisk)
 		{
+			// IMPORTANT: Call UnloadMenuFromDisk which now uses RemoveMenuFromContext
 			UnloadMenuFromDisk(element.first);
 		}
 
@@ -1506,24 +1419,15 @@ namespace Components
 			OverridenMenus.clear();
 		}
 
-		ReloadingMenus = false;
-
-		// Step 2: Load connect first so stock connect is never shown during level startup.
-		LoadCustomConnectMenu();
-
-		// Step 3: Load everything else
+		// Step 2: Load everything
 		{
 			const auto menus = FileSystem::GetFileList("ui_mp", "menu", Game::FS_LIST_ALL);
 
 			// Load standalone menus
 			for (const auto& filename : menus)
 			{
-				if (IsCustomMenuFile(filename))
-				{
-					continue;
-				}
-
 				const std::string fullPath = std::format("ui_mp\\{}", filename);
+
 				LoadScriptMenu(fullPath.c_str(), allowStrayMenus);
 			}
 
@@ -1554,19 +1458,11 @@ namespace Components
 			// "code.txt" for IW4x
 			for (const auto& menuName : CustomIW4xMenus)
 			{
-				auto normalizedMenuName = menuName;
-				Utils::String::Replace(normalizedMenuName, "/", "\\");
-				if (!_stricmp(normalizedMenuName.data(), "ui_mp\\connect.menu"))
-				{
-					continue;
-				}
-
 				LoadScriptMenu(menuName.c_str(), true);
 			}
 		}
 
-		// Step 4 - Keep supporting data around
-		EnsureCustomConnectMenu();
+		// Step 3 - Keep supporting data around
 
 		// Debug-only check
 		CheckMenus();
@@ -1574,11 +1470,6 @@ namespace Components
 
 	bool Menus::IsMenuVisible(Game::UiContext* dc, Game::menuDef_t* menu)
 	{
-		if (!ShuttingDown && !ReloadingMenus)
-		{
-			EnsureCustomConnectMenu();
-		}
-
 		if (menu && menu->window.name)
 		{
 			if (menu->window.name == "connect"s) // Check if we're supposed to draw the loadscreen
@@ -1702,7 +1593,9 @@ namespace Components
 		Components::Events::OnCGameInit(ReloadDiskMenus_OnCGameStart);
 		Components::Events::AfterUIInit(ReloadDiskMenus_OnUIInitialization);
 
-		// Keep disk-loaded menu overrides visible to direct asset lookups, including connect.menu.
+		// --- HOOK ASSET HANDLER ---
+		// These hooks were present in your OLD working code.
+		// They are the key to intercepting asset lookup calls via AssetHandler.
 		AssetHandler::OnFind(Game::ASSET_TYPE_MENU, MenuFindHook);
 		AssetHandler::OnFind(Game::ASSET_TYPE_MENULIST, MenuListFindHook);
 
@@ -1728,24 +1621,14 @@ namespace Components
 				}
 			}, HOOK_CALL).install()->quick();
 
-		// Intercept menu painting so a loaded custom connect menu wins over the stock one.
+		// Intercept menu painting (This hook was in old code)
 		Utils::Hook(0x4FFBDF, IsMenuVisible, HOOK_CALL).install()->quick();
-		Components::Scheduler::Schedule([]
-			{
-				if (ShuttingDown)
-				{
-					return true;
-				}
-
-				EnsureCustomConnectMenu();
-				return false;
-			}, Components::Scheduler::Pipeline::MAIN);
 
 		// disable the 2 new tokens in ItemParse_rect (Fix by NTA. Probably because he didn't want to update the menus)
 		Utils::Hook::Set<std::uint8_t>(0x640693, 0xEB);
 
-		// don't load ASSET_TYPE_MENU assets for every menu (might cause patch menus to fail).
-		Utils::Hook::Nop(0x453406, 5);
+		// don't load ASSET_TYPE_MENU assets for every menu (might cause patch menus to fail) (This NOP was in old code)
+		Utils::Hook::Nop(0x453406, 5); // Re-added this NOP
 
 		// make Com_Error and similar go back to main_text instead of menu_xboxlive.
 		Utils::Hook::SetString(0x6FC790, "main_text");
@@ -1815,7 +1698,7 @@ namespace Components
 		// The "reloadmenus" command from the old code is removed here as the new system's ReloadDiskMenus() handles it differently.
 		// Command::Add("reloadmenus", []() { ... });
 
-		// Define custom menus here. ReloadDiskMenus() loads these alongside discovered disk menus.
+		// Define custom menus here (Keep this, as ReloadDiskMenus() still uses it)
 		Add("ui_mp/changelog.menu");
 		Add("ui_mp/iw4x_credits.menu");
 		Add("ui_mp/menu_first_launch.menu");
@@ -1842,30 +1725,31 @@ namespace Components
 
 	void Menus::preDestroy()
 	{
-		ShuttingDown = true;
-
 		// Let Windows handle the memory leaks for you!
 		// The old code had Menus::FreeEverything(); here.
 		// If the new system handles freeing globally, this might not be needed.
 	}
 }
 
-// Return disk-loaded menus to direct asset lookups, while falling back to stock assets when absent.
+// --- Implement AssetHandler hooks (from old Menus.cpp) ---
+// These will act as the new AssetHandler for menus, routing to your internal loaders.
 namespace Components
 {
 	Game::XAssetHeader Menus::MenuFindHook(Game::XAssetType /*type*/, const std::string& filename)
 	{
-		// Asset requests can arrive as "connect", "connect.menu", or with a ui_mp path.
+		// This hook needs to return YOUR loaded menu, if it exists in MenusFromDisk.
+		// Otherwise, it should call the original game function to find the asset.
+		// Since we don't have a direct "DB_FindXAssetHeader_Original" in this strategy,
+		// we rely on the game's default asset handler to load it if we don't have it.
+		// The ImenuDef_t::load function (which is part of the AssetHandler process)
+		// will handle loading from disk.
+
+		// Clean the name similar to DB_FindXAssetHeader_Hook logic in the previous attempt
 		std::string shortName = filename;
 		size_t lastSlash = shortName.find_last_of("/\\");
 		if (lastSlash != std::string::npos) shortName = shortName.substr(lastSlash + 1);
 		if (shortName.length() > 5 && shortName.substr(shortName.length() - 5) == ".menu") {
 			shortName = shortName.substr(0, shortName.length() - 5);
-		}
-
-		if (!_stricmp(shortName.data(), "connect"))
-		{
-			LoadCustomConnectMenu();
 		}
 
 		if (MenusFromDisk.contains(shortName))
@@ -1874,7 +1758,10 @@ namespace Components
 			return { MenusFromDisk[shortName] };
 		}
 
-		// Returning nullptr lets the original DB_FindXAssetHeader path handle stock menus.
+		// If not found in our custom map, let the game's default DB_FindXAssetHeader handle it.
+		// The AssetHandler::IAsset::load implementation (e.g., in ImenuDef_t.cpp)
+		// will be responsible for loading the actual game asset or calling our LoadMenuByName_Recursive.
+		// Returning a nullptr XAssetHeader might force the AssetHandler to call the IAsset::load method.
 		DebugPrint("MenuFindHook: Menu '{}' not found in custom list. Returning nullptr to trigger default AssetHandler load.", shortName);
 		return { nullptr };
 	}
@@ -1883,14 +1770,14 @@ namespace Components
 	{
 		(void)type;
 
-		// Return a disk-loaded menu list when one was registered under the requested name.
+		// This hook needs to return YOUR loaded menulist, if it exists.
 		if (MenuListsFromDisk.contains(filename))
 		{
 			DebugPrint("MenuListFindHook: Intercepted request for menulist '{}'. Returning custom menulist ({:X})", filename, (unsigned int)MenuListsFromDisk[filename]);
 			return { MenuListsFromDisk[filename] };
 		}
 
-		// Returning nullptr lets the original DB_FindXAssetHeader path handle stock menu lists.
+		// If not found in our custom map, let the game's default DB_FindXAssetHeader handle it.
 		DebugPrint("MenuListFindHook: Menulist '{}' not found in custom list. Returning nullptr to trigger default AssetHandler load.", filename);
 		return { nullptr };
 	}

--- a/src/Components/Modules/Menus.hpp
+++ b/src/Components/Modules/Menus.hpp
@@ -40,6 +40,7 @@ namespace Components
 		static Utils::Memory::Allocator Allocator;
 
 		static bool MenuAlreadyExists(const std::string& name);
+		static void AddMenuAlias(const std::string& source, const std::string& alias);
 
 		static void FreeZAllocatedMemory(const void* ptr, bool fromTheGame = false);
 		static void FreeAllocatedString(const void* ptr, bool fromTheGame = false);

--- a/src/Components/Modules/Menus.hpp
+++ b/src/Components/Modules/Menus.hpp
@@ -17,8 +17,11 @@ namespace Components
 
 		static bool IsMenuVisible(Game::UiContext* dc, Game::menuDef_t* menu);
 
+		static void RemoveMenuFromContext(Game::UiContext* dc, Game::menuDef_t* menuToRemove);
+
 		static Game::XAssetHeader MenuFindHook(Game::XAssetType type, const std::string& filename);
 		static Game::XAssetHeader MenuListFindHook(Game::XAssetType type, const std::string& filename);
+
 
 	private:
 		static std::unordered_map<std::string, Game::menuDef_t*> MenusFromDisk;
@@ -35,14 +38,8 @@ namespace Components
 		static std::vector<std::string> CustomIW4xMenus;
 
 		static Utils::Memory::Allocator Allocator;
-		static bool ShuttingDown;
-		static bool ReloadingMenus;
 
 		static bool MenuAlreadyExists(const std::string& name);
-		static bool IsCustomMenuPath(const std::string& menu);
-		static bool IsCustomMenuFile(const std::string& filename);
-		static void EnsureCustomConnectMenu();
-		static bool LoadCustomConnectMenu();
 
 		static void FreeZAllocatedMemory(const void* ptr, bool fromTheGame = false);
 		static void FreeAllocatedString(const void* ptr, bool fromTheGame = false);

--- a/src/Components/Modules/Menus.hpp
+++ b/src/Components/Modules/Menus.hpp
@@ -17,11 +17,8 @@ namespace Components
 
 		static bool IsMenuVisible(Game::UiContext* dc, Game::menuDef_t* menu);
 
-		static void RemoveMenuFromContext(Game::UiContext* dc, Game::menuDef_t* menuToRemove);
-
 		static Game::XAssetHeader MenuFindHook(Game::XAssetType type, const std::string& filename);
 		static Game::XAssetHeader MenuListFindHook(Game::XAssetType type, const std::string& filename);
-
 
 	private:
 		static std::unordered_map<std::string, Game::menuDef_t*> MenusFromDisk;
@@ -38,8 +35,14 @@ namespace Components
 		static std::vector<std::string> CustomIW4xMenus;
 
 		static Utils::Memory::Allocator Allocator;
+		static bool ShuttingDown;
+		static bool ReloadingMenus;
 
 		static bool MenuAlreadyExists(const std::string& name);
+		static bool IsCustomMenuPath(const std::string& menu);
+		static bool IsCustomMenuFile(const std::string& filename);
+		static void EnsureCustomConnectMenu();
+		static bool LoadCustomConnectMenu();
 
 		static void FreeZAllocatedMemory(const void* ptr, bool fromTheGame = false);
 		static void FreeAllocatedString(const void* ptr, bool fromTheGame = false);

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -119,8 +119,9 @@ namespace Components {
 							const auto* currentName = material->textureTable[i].u.image->name ? material->textureTable[i].u.image->name : "";
 							const bool isDefault = strstr(currentName, "default") != nullptr;
 							const bool isOldPreview = strstr(currentName, "preview_") != nullptr && strstr(currentName, image->name) == nullptr;
+							const bool isOldLoadscreen = strstr(currentName, "loadscreen_") != nullptr && strstr(currentName, image->name) == nullptr;
 
-							if (isDefault || (isOldPreview && isElementExplicit))
+							if (isDefault || ((isOldPreview || isOldLoadscreen) && isElementExplicit))
 							{
 								material->textureTable[i].u.image = image;
 							}

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -8,6 +8,71 @@
 namespace Components {
 	void(*SPLoadscreens::OriginalMapCommand)() = nullptr;
 
+	namespace
+	{
+		void StorePreviewMaterial(const std::string& name, Game::GfxImage* image)
+		{
+			if (!image || strstr(image->name, "default"))
+			{
+				return;
+			}
+
+			Game::XAssetHeader existing = AssetHandler::FindTemporaryAsset(Game::ASSET_TYPE_MATERIAL, name.data());
+			if (existing.material && existing.material->textureCount > 0 && existing.material->textureTable && existing.material->textureTable[0].u.image == image)
+			{
+				return;
+			}
+
+			AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_MATERIAL, { Materials::Create(name, image) });
+		}
+
+		Game::GfxImage* GetPreviewImageForMap(const std::string& mapname)
+		{
+			if (mapname.empty()) return nullptr;
+
+			// If the map name starts with "mp_", we skip it entirely
+			if (Utils::String::StartsWith(mapname, "mp_"))
+			{
+				return nullptr;
+			}
+
+			std::vector<std::string> variants = { "preview_" + mapname };
+
+			// Handle potential underscores
+			if (mapname.find('_') != std::string::npos)
+			{
+				std::string simpleName = mapname;
+				Utils::String::Replace(simpleName, "_", "");
+				variants.push_back("preview_" + simpleName);
+			}
+
+			for (const auto& variant : variants)
+			{
+				if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
+				{
+					Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
+					if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
+					{
+						imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
+						AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
+					}
+
+					return imageHeader.image;
+				}
+			}
+
+			return nullptr;
+		}
+	}
+
+	void SPLoadscreens::PreloadMapPreview(const std::string& mapname)
+	{
+		Game::GfxImage* image = GetPreviewImageForMap(mapname);
+		StorePreviewMaterial("loading_image", image);
+		StorePreviewMaterial("level_loadscreen", image);
+		StorePreviewMaterial("loadscreen_" + mapname, image);
+	}
+
 	void SPLoadscreens::InstallMapCommandHook()
 	{
 		Scheduler::Schedule([]
@@ -24,6 +89,7 @@ namespace Components {
 						if (params->size() > 1 && *Game::ui_mapname && !Utils::String::StartsWith(params->get(1), "mp_"))
 						{
 							Game::Dvar_SetString(*Game::ui_mapname, params->get(1));
+							PreloadMapPreview(params->get(1));
 						}
 
 						if (OriginalMapCommand)
@@ -56,39 +122,7 @@ namespace Components {
 					}
 				}
 
-				if (mapname.empty()) return nullptr;
-
-				// If the map name starts with "mp_", we skip it entirely
-				if (Utils::String::StartsWith(mapname, "mp_"))
-				{
-					return nullptr;
-				}
-
-				std::vector<std::string> variants = { "preview_" + mapname };
-
-				// Handle potential underscores
-				if (mapname.find('_') != std::string::npos)
-				{
-					std::string simpleName = mapname;
-					Utils::String::Replace(simpleName, "_", "");
-					variants.push_back("preview_" + simpleName);
-				}
-
-				for (const auto& variant : variants)
-				{
-					if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
-					{
-						Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
-						if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
-						{
-							imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
-							AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
-						}
-						return imageHeader.image;
-					}
-				}
-
-				return nullptr;
+				return GetPreviewImageForMap(mapname);
 			};
 
 		auto patchMaterial = [getPreviewImage](Game::Material* material, const std::string& name, bool isElementExplicit)

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -73,7 +73,9 @@ namespace Components {
 							bool isDefault = strstr(material->textureTable[i].u.image->name, "default") != nullptr;
 							bool isOldPreview = strstr(material->textureTable[i].u.image->name, "preview_") != nullptr &&
 								strstr(material->textureTable[i].u.image->name, image->name) == nullptr;
-							if (isDefault || (isOldPreview && isElementExplicit))
+							bool isOldLoadscreen = strstr(material->textureTable[i].u.image->name, "loadscreen_") != nullptr &&
+								strstr(material->textureTable[i].u.image->name, image->name) == nullptr;
+							if (isDefault || ((isOldPreview || isOldLoadscreen) && isElementExplicit))
 							{
 								material->textureTable[i].u.image = image;
 							}

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -1,5 +1,4 @@
 #include "SPLoadscreens.hpp"
-#include "Command.hpp"
 #include "AssetHandler.hpp"
 #include "FileSystem.hpp"
 #include "Materials.hpp"
@@ -7,50 +6,14 @@
 
 namespace Components {
 	std::string SPLoadscreens::LoadingMap;
-	void(*SPLoadscreens::OriginalMapCommand)() = nullptr;
 
 	void SPLoadscreens::SetLoadingMap(const std::string& mapname)
 	{
 		LoadingMap = mapname;
 	}
 
-	void SPLoadscreens::MapCommandStub()
-	{
-		Command::ClientParams params;
-		if (params.size() > 1)
-		{
-			SetLoadingMap(params.get(1));
-		}
-
-		if (OriginalMapCommand)
-		{
-			OriginalMapCommand();
-		}
-	}
-
-	void SPLoadscreens::InstallMapCommandHook()
-	{
-		Scheduler::Schedule([]
-			{
-				auto* mapCommand = Command::Find("map");
-				if (!mapCommand || !mapCommand->function)
-				{
-					return false;
-				}
-
-				if (mapCommand->function != MapCommandStub)
-				{
-					OriginalMapCommand = mapCommand->function;
-					mapCommand->function = MapCommandStub;
-				}
-
-				return true;
-			}, Scheduler::Pipeline::MAIN);
-	}
-
 	SPLoadscreens::SPLoadscreens()
 	{
-		InstallMapCommandHook();
 		auto getPreviewImage = [](const std::string& materialName) -> Game::GfxImage*
 			{
 				auto findPreviewForMap = [](const std::string& mapname) -> Game::GfxImage*

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -1,12 +1,44 @@
 #include "SPLoadscreens.hpp"
+#include "Command.hpp"
 #include "AssetHandler.hpp"
 #include "FileSystem.hpp"
 #include "Materials.hpp"
 #include "STDInclude.hpp"
 
 namespace Components {
+	void(*SPLoadscreens::OriginalMapCommand)() = nullptr;
+
+	void SPLoadscreens::InstallMapCommandHook()
+	{
+		Scheduler::Schedule([]
+			{
+				auto* mapCommand = Command::Find("map");
+				if (!mapCommand || !mapCommand->function)
+				{
+					return false;
+				}
+
+				OriginalMapCommand = mapCommand->function;
+				Command::Add("map", [](const Command::Params* params)
+					{
+						if (params->size() > 1 && *Game::ui_mapname && !Utils::String::StartsWith(params->get(1), "mp_"))
+						{
+							Game::Dvar_SetString(*Game::ui_mapname, params->get(1));
+						}
+
+						if (OriginalMapCommand)
+						{
+							OriginalMapCommand();
+						}
+					});
+
+				return true;
+			}, Scheduler::Pipeline::MAIN);
+	}
+
 	SPLoadscreens::SPLoadscreens()
 	{
+		InstallMapCommandHook();
 		auto getPreviewImage = [](const std::string& materialName) -> Game::GfxImage*
 			{
 				std::string mapname = "";

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -1,58 +1,136 @@
 #include "SPLoadscreens.hpp"
+#include "Command.hpp"
 #include "AssetHandler.hpp"
 #include "FileSystem.hpp"
 #include "Materials.hpp"
 #include "STDInclude.hpp"
 
 namespace Components {
+	std::string SPLoadscreens::LoadingMap;
+	void(*SPLoadscreens::OriginalMapCommand)() = nullptr;
+
+	void SPLoadscreens::SetLoadingMap(const std::string& mapname)
+	{
+		LoadingMap = mapname;
+	}
+
+	void SPLoadscreens::MapCommandStub()
+	{
+		Command::ClientParams params;
+		if (params.size() > 1)
+		{
+			SetLoadingMap(params.get(1));
+		}
+
+		if (OriginalMapCommand)
+		{
+			OriginalMapCommand();
+		}
+	}
+
+	void SPLoadscreens::InstallMapCommandHook()
+	{
+		Scheduler::Schedule([]
+			{
+				auto* mapCommand = Command::Find("map");
+				if (!mapCommand || !mapCommand->function)
+				{
+					return false;
+				}
+
+				if (mapCommand->function != MapCommandStub)
+				{
+					OriginalMapCommand = mapCommand->function;
+					mapCommand->function = MapCommandStub;
+				}
+
+				return true;
+			}, Scheduler::Pipeline::MAIN);
+	}
+
 	SPLoadscreens::SPLoadscreens()
 	{
+		InstallMapCommandHook();
 		auto getPreviewImage = [](const std::string& materialName) -> Game::GfxImage*
 			{
-				std::string mapname = "";
+				auto findPreviewForMap = [](const std::string& mapname) -> Game::GfxImage*
+				{
+					if (mapname.empty() || Utils::String::StartsWith(mapname, "mp_"))
+					{
+						return nullptr;
+					}
+
+					std::vector<std::string> variants = { "preview_" + mapname };
+
+					if (mapname.find('_') != std::string::npos)
+					{
+						std::string simpleName = mapname;
+						Utils::String::Replace(simpleName, "_", "");
+						variants.push_back("preview_" + simpleName);
+					}
+
+					for (const auto& variant : variants)
+					{
+						if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
+						{
+							Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
+							if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
+							{
+								imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
+								AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
+							}
+							return imageHeader.image;
+						}
+					}
+
+					return nullptr;
+				};
+
 				if (Utils::String::StartsWith(materialName, "loadscreen_"))
 				{
-					mapname = materialName.substr(11);
-				}
-				else
-				{
-					// Fallback to current map dvar if it's a generic loadscreen material
-					Game::dvar_t* ui_mapname = Game::Dvar_FindVar("ui_mapname");
-					if (ui_mapname && ui_mapname->current.string)
+					const auto explicitMap = materialName.substr(11);
+					if (auto* image = findPreviewForMap(explicitMap))
 					{
-						mapname = ui_mapname->current.string;
+						LoadingMap = explicitMap;
+						return image;
 					}
 				}
 
-				if (mapname.empty()) return nullptr;
+				const auto* uiMapDvar = Game::Dvar_FindVar("ui_mapname");
+				const auto* mapDvar = Game::Dvar_FindVar("mapname");
+				const auto* uiMap = (uiMapDvar && uiMapDvar->current.string) ? uiMapDvar->current.string : "";
+				const auto* map = (mapDvar && mapDvar->current.string) ? mapDvar->current.string : "";
 
-				// If the map name starts with "mp_", we skip it entirely
-				if (Utils::String::StartsWith(mapname, "mp_"))
+				// When changing SP maps from the console, ui_mapname can point at the requested
+				// map while mapname still points at the currently running map. Prefer that
+				// transition target before the last explicit loadscreen material we saw.
+				if (*uiMap && _stricmp(uiMap, map))
 				{
-					return nullptr;
-				}
-
-				std::vector<std::string> variants = { "preview_" + mapname };
-
-				// Handle potential underscores
-				if (mapname.find('_') != std::string::npos)
-				{
-					std::string simpleName = mapname;
-					Utils::String::Replace(simpleName, "_", "");
-					variants.push_back("preview_" + simpleName);
-				}
-
-				for (const auto& variant : variants)
-				{
-					if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
+					if (auto* image = findPreviewForMap(uiMap))
 					{
-						Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
-						if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
+						return image;
+					}
+				}
+
+				if (!LoadingMap.empty())
+				{
+					if (auto* image = findPreviewForMap(LoadingMap))
+					{
+						return image;
+					}
+				}
+
+				// Generic loading materials are reused between SP maps. ui_mapname tends to be
+				// updated for the requested map before the read-only mapname dvar changes.
+				for (const auto* dvarName : { "ui_mapname", "mapname", "sv_mapname" })
+				{
+					Game::dvar_t* dvar = Game::Dvar_FindVar(dvarName);
+					if (dvar && dvar->current.string)
+					{
+						if (auto* image = findPreviewForMap(dvar->current.string))
 						{
-							imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
-							AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
+							return image;
 						}
-						return imageHeader.image;
 					}
 				}
 
@@ -64,15 +142,21 @@ namespace Components {
 				if (!material) return;
 
 				Game::GfxImage* image = getPreviewImage(name);
+				if (!image && material->info.name)
+				{
+					image = getPreviewImage(material->info.name);
+				}
+
 				if (image && !strstr(image->name, "default"))
 				{
 					for (int i = 0; i < material->textureCount; ++i)
 					{
 						if (material->textureTable[i].u.image)
 						{
-							bool isDefault = strstr(material->textureTable[i].u.image->name, "default") != nullptr;
-							bool isOldPreview = strstr(material->textureTable[i].u.image->name, "preview_") != nullptr &&
-								strstr(material->textureTable[i].u.image->name, image->name) == nullptr;
+							const auto* currentName = material->textureTable[i].u.image->name ? material->textureTable[i].u.image->name : "";
+							const bool isDefault = strstr(currentName, "default") != nullptr;
+							const bool isOldPreview = strstr(currentName, "preview_") != nullptr && strstr(currentName, image->name) == nullptr;
+
 							if (isDefault || (isOldPreview && isElementExplicit))
 							{
 								material->textureTable[i].u.image = image;
@@ -100,26 +184,16 @@ namespace Components {
 				return { nullptr };
 			});
 
-		AssetHandler::OnLoad([getPreviewImage](Game::XAssetType type, Game::XAssetHeader asset, const std::string& name, bool*)
+		AssetHandler::OnLoad([patchMaterial](Game::XAssetType type, Game::XAssetHeader asset, const std::string& name, bool*)
 			{
 				if (type == Game::ASSET_TYPE_MATERIAL && (Utils::String::Contains(name, "loadscreen") || name == "loading_image"))
 				{
-					Game::GfxImage* image = getPreviewImage(name);
-					if (image && !strstr(image->name, "default"))
-					{
-						for (int i = 0; i < asset.material->textureCount; ++i)
-						{
-							if (asset.material->textureTable[i].u.image && strstr(asset.material->textureTable[i].u.image->name, "default"))
-							{
-								asset.material->textureTable[i].u.image = image;
-							}
-						}
-					}
+					patchMaterial(asset.material, name, true);
 				}
 			});
 
 		// Active monitoring for the connect menu
-		Scheduler::Loop([getPreviewImage, patchMaterial]()
+		Scheduler::Loop([patchMaterial]()
 			{
 				Game::menuDef_t* connectMenu = Game::Menus_FindByName(Game::uiContext, "connect");
 				if (connectMenu && Game::Menu_IsVisible(Game::uiContext, connectMenu))
@@ -137,14 +211,17 @@ namespace Components {
 							if (item->window.name)
 							{
 								std::string winName = item->window.name;
-								if (Utils::String::Contains(winName, "loadscreen") || Utils::String::Contains(winName, "preview"))
-								{
-									isExplicitTarget = true;
-								}
+								isExplicitTarget = Utils::String::Contains(winName, "loadscreen") || Utils::String::Contains(winName, "preview");
 							}
 							else
 							{
 								isExplicitTarget = true;
+							}
+
+							if (!isExplicitTarget && item->window.background && item->window.background->info.name)
+							{
+								isExplicitTarget = Utils::String::Contains(item->window.background->info.name, "loadscreen") ||
+									Utils::String::Contains(item->window.background->info.name, "preview");
 							}
 
 							patchMaterial(item->window.background, item->window.name ? item->window.name : "level_loadscreen", isExplicitTarget);

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -5,95 +5,54 @@
 #include "STDInclude.hpp"
 
 namespace Components {
-	std::string SPLoadscreens::LoadingMap;
-
-	void SPLoadscreens::SetLoadingMap(const std::string& mapname)
-	{
-		LoadingMap = mapname;
-	}
-
 	SPLoadscreens::SPLoadscreens()
 	{
 		auto getPreviewImage = [](const std::string& materialName) -> Game::GfxImage*
 			{
-				auto findPreviewForMap = [](const std::string& mapname) -> Game::GfxImage*
-				{
-					if (mapname.empty() || Utils::String::StartsWith(mapname, "mp_"))
-					{
-						return nullptr;
-					}
-
-					std::vector<std::string> variants = { "preview_" + mapname };
-
-					if (mapname.find('_') != std::string::npos)
-					{
-						std::string simpleName = mapname;
-						Utils::String::Replace(simpleName, "_", "");
-						variants.push_back("preview_" + simpleName);
-					}
-
-					for (const auto& variant : variants)
-					{
-						if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
-						{
-							Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
-							if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
-							{
-								imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
-								AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
-							}
-							return imageHeader.image;
-						}
-					}
-
-					return nullptr;
-				};
-
+				std::string mapname = "";
 				if (Utils::String::StartsWith(materialName, "loadscreen_"))
 				{
-					const auto explicitMap = materialName.substr(11);
-					if (auto* image = findPreviewForMap(explicitMap))
+					mapname = materialName.substr(11);
+				}
+				else
+				{
+					// Fallback to current map dvar if it's a generic loadscreen material
+					Game::dvar_t* ui_mapname = Game::Dvar_FindVar("ui_mapname");
+					if (ui_mapname && ui_mapname->current.string)
 					{
-						LoadingMap = explicitMap;
-						return image;
+						mapname = ui_mapname->current.string;
 					}
 				}
 
-				const auto* uiMapDvar = Game::Dvar_FindVar("ui_mapname");
-				const auto* mapDvar = Game::Dvar_FindVar("mapname");
-				const auto* uiMap = (uiMapDvar && uiMapDvar->current.string) ? uiMapDvar->current.string : "";
-				const auto* map = (mapDvar && mapDvar->current.string) ? mapDvar->current.string : "";
+				if (mapname.empty()) return nullptr;
 
-				// When changing SP maps from the console, ui_mapname can point at the requested
-				// map while mapname still points at the currently running map. Prefer that
-				// transition target before the last explicit loadscreen material we saw.
-				if (*uiMap && _stricmp(uiMap, map))
+				// If the map name starts with "mp_", we skip it entirely
+				if (Utils::String::StartsWith(mapname, "mp_"))
 				{
-					if (auto* image = findPreviewForMap(uiMap))
-					{
-						return image;
-					}
+					return nullptr;
 				}
 
-				if (!LoadingMap.empty())
+				std::vector<std::string> variants = { "preview_" + mapname };
+
+				// Handle potential underscores
+				if (mapname.find('_') != std::string::npos)
 				{
-					if (auto* image = findPreviewForMap(LoadingMap))
-					{
-						return image;
-					}
+					std::string simpleName = mapname;
+					Utils::String::Replace(simpleName, "_", "");
+					variants.push_back("preview_" + simpleName);
 				}
 
-				// Generic loading materials are reused between SP maps. ui_mapname tends to be
-				// updated for the requested map before the read-only mapname dvar changes.
-				for (const auto* dvarName : { "ui_mapname", "mapname", "sv_mapname" })
+				for (const auto& variant : variants)
 				{
-					Game::dvar_t* dvar = Game::Dvar_FindVar(dvarName);
-					if (dvar && dvar->current.string)
+					if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
 					{
-						if (auto* image = findPreviewForMap(dvar->current.string))
+						Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
+						if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
 						{
-							return image;
+							imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
+							AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
 						}
+						return imageHeader.image;
 					}
 				}
 
@@ -105,23 +64,16 @@ namespace Components {
 				if (!material) return;
 
 				Game::GfxImage* image = getPreviewImage(name);
-				if (!image && material->info.name)
-				{
-					image = getPreviewImage(material->info.name);
-				}
-
 				if (image && !strstr(image->name, "default"))
 				{
 					for (int i = 0; i < material->textureCount; ++i)
 					{
 						if (material->textureTable[i].u.image)
 						{
-							const auto* currentName = material->textureTable[i].u.image->name ? material->textureTable[i].u.image->name : "";
-							const bool isDefault = strstr(currentName, "default") != nullptr;
-							const bool isOldPreview = strstr(currentName, "preview_") != nullptr && strstr(currentName, image->name) == nullptr;
-							const bool isOldLoadscreen = strstr(currentName, "loadscreen_") != nullptr && strstr(currentName, image->name) == nullptr;
-
-							if (isDefault || ((isOldPreview || isOldLoadscreen) && isElementExplicit))
+							bool isDefault = strstr(material->textureTable[i].u.image->name, "default") != nullptr;
+							bool isOldPreview = strstr(material->textureTable[i].u.image->name, "preview_") != nullptr &&
+								strstr(material->textureTable[i].u.image->name, image->name) == nullptr;
+							if (isDefault || (isOldPreview && isElementExplicit))
 							{
 								material->textureTable[i].u.image = image;
 							}
@@ -148,16 +100,26 @@ namespace Components {
 				return { nullptr };
 			});
 
-		AssetHandler::OnLoad([patchMaterial](Game::XAssetType type, Game::XAssetHeader asset, const std::string& name, bool*)
+		AssetHandler::OnLoad([getPreviewImage](Game::XAssetType type, Game::XAssetHeader asset, const std::string& name, bool*)
 			{
 				if (type == Game::ASSET_TYPE_MATERIAL && (Utils::String::Contains(name, "loadscreen") || name == "loading_image"))
 				{
-					patchMaterial(asset.material, name, true);
+					Game::GfxImage* image = getPreviewImage(name);
+					if (image && !strstr(image->name, "default"))
+					{
+						for (int i = 0; i < asset.material->textureCount; ++i)
+						{
+							if (asset.material->textureTable[i].u.image && strstr(asset.material->textureTable[i].u.image->name, "default"))
+							{
+								asset.material->textureTable[i].u.image = image;
+							}
+						}
+					}
 				}
 			});
 
 		// Active monitoring for the connect menu
-		Scheduler::Loop([patchMaterial]()
+		Scheduler::Loop([getPreviewImage, patchMaterial]()
 			{
 				Game::menuDef_t* connectMenu = Game::Menus_FindByName(Game::uiContext, "connect");
 				if (connectMenu && Game::Menu_IsVisible(Game::uiContext, connectMenu))
@@ -175,17 +137,14 @@ namespace Components {
 							if (item->window.name)
 							{
 								std::string winName = item->window.name;
-								isExplicitTarget = Utils::String::Contains(winName, "loadscreen") || Utils::String::Contains(winName, "preview");
+								if (Utils::String::Contains(winName, "loadscreen") || Utils::String::Contains(winName, "preview"))
+								{
+									isExplicitTarget = true;
+								}
 							}
 							else
 							{
 								isExplicitTarget = true;
-							}
-
-							if (!isExplicitTarget && item->window.background && item->window.background->info.name)
-							{
-								isExplicitTarget = Utils::String::Contains(item->window.background->info.name, "loadscreen") ||
-									Utils::String::Contains(item->window.background->info.name, "preview");
 							}
 
 							patchMaterial(item->window.background, item->window.name ? item->window.name : "level_loadscreen", isExplicitTarget);

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -64,6 +64,11 @@ namespace Components {
 				if (!material) return;
 
 				Game::GfxImage* image = getPreviewImage(name);
+				if (!image && material->info.name)
+				{
+					image = getPreviewImage(material->info.name);
+				}
+
 				if (image && !strstr(image->name, "default"))
 				{
 					for (int i = 0; i < material->textureCount; ++i)
@@ -147,6 +152,12 @@ namespace Components {
 							else
 							{
 								isExplicitTarget = true;
+							}
+
+							if (!isExplicitTarget && item->window.background && item->window.background->info.name)
+							{
+								isExplicitTarget = Utils::String::Contains(item->window.background->info.name, "loadscreen") ||
+									Utils::String::Contains(item->window.background->info.name, "preview");
 							}
 
 							patchMaterial(item->window.background, item->window.name ? item->window.name : "level_loadscreen", isExplicitTarget);

--- a/src/Components/Modules/SPLoadscreens.hpp
+++ b/src/Components/Modules/SPLoadscreens.hpp
@@ -7,10 +7,5 @@ namespace Components
 	public:
 		SPLoadscreens();
 		~SPLoadscreens();
-
-		static void SetLoadingMap(const std::string& mapname);
-
-	private:
-		static std::string LoadingMap;
 	};
 }

--- a/src/Components/Modules/SPLoadscreens.hpp
+++ b/src/Components/Modules/SPLoadscreens.hpp
@@ -7,5 +7,14 @@ namespace Components
 	public:
 		SPLoadscreens();
 		~SPLoadscreens();
+
+		static void SetLoadingMap(const std::string& mapname);
+
+	private:
+		static std::string LoadingMap;
+		static void(*OriginalMapCommand)();
+
+		static void MapCommandStub();
+		static void InstallMapCommandHook();
 	};
 }

--- a/src/Components/Modules/SPLoadscreens.hpp
+++ b/src/Components/Modules/SPLoadscreens.hpp
@@ -7,5 +7,9 @@ namespace Components
 	public:
 		SPLoadscreens();
 		~SPLoadscreens();
+
+	private:
+		static void(*OriginalMapCommand)();
+		static void InstallMapCommandHook();
 	};
 }

--- a/src/Components/Modules/SPLoadscreens.hpp
+++ b/src/Components/Modules/SPLoadscreens.hpp
@@ -8,6 +8,8 @@ namespace Components
 		SPLoadscreens();
 		~SPLoadscreens();
 
+		static void PreloadMapPreview(const std::string& mapname);
+
 	private:
 		static void(*OriginalMapCommand)();
 		static void InstallMapCommandHook();

--- a/src/Components/Modules/SPLoadscreens.hpp
+++ b/src/Components/Modules/SPLoadscreens.hpp
@@ -12,9 +12,5 @@ namespace Components
 
 	private:
 		static std::string LoadingMap;
-		static void(*OriginalMapCommand)();
-
-		static void MapCommandStub();
-		static void InstallMapCommandHook();
 	};
 }


### PR DESCRIPTION
### Motivation

- Ensure disk-loaded menus can reliably override and replace stock menus (especially `connect`) without showing the original during level startup. 
- Prevent leftover/lingering menu pointers and leaks when reloading/unloading menus and when switching context. 
- Provide better singleplayer loadscreen previews by tracking requested map changes and selecting appropriate preview images. 

### Description

- Reworked menu override lifecycle: added `ShuttingDown` and `ReloadingMenus` flags, new helpers `IsCustomMenuPath`, `IsCustomMenuFile`, `EnsureCustomConnectMenu`, and `LoadCustomConnectMenu`, and updated `MenuAlreadyExists` semantics in `Menus`. 
- Rewrote override handling in `PrepareToUnloadMenu` and `AfterLoadedMenuFromDisk` to track originals in `OverridenMenus`, restore replacements cleanly across all `GameUiContexts`, and avoid double-add/remove bugs. 
- Improved reload flow in `ReloadDiskMenus` to protect against races and to load the custom `connect` menu first, skip custom files in the main load pass, and call `EnsureCustomConnectMenu` after loading. 
- Asset handler integration: `MenuFindHook` and `MenuListFindHook` now return disk-loaded menu/menu-list assets when present and will trigger loading the custom `connect` as needed, while falling back to the original asset path when absent. 
- UI painting and scheduler hooks: hooked `IsMenuVisible` to prefer disk-loaded `connect` and scheduled a keep-alive to ensure `connect` is replaced early; set `ShuttingDown` in `preDestroy`. 
- Singleplayer loadscreen improvements: added `SPLoadscreens::SetLoadingMap`, a `map` command hook to track requested SP map transitions, improved preview image lookup and material patching logic, and registered these in `SPLoadscreens.hpp/.cpp`. 
- Minor integration: `Maps::PrepareUsermap` now calls `SPLoadscreens::SetLoadingMap` when a user map is prepared, and headers updated accordingly. 

### Testing

- Project build: performed a full debug build which completed successfully. 
- Automated tests: ran the repository's automated build-and-smoke test harness which exercised `ReloadDiskMenus`, loading of `ui_mp\connect.menu` via `LoadScriptMenu`, and the material patching scheduler loop; these smoke checks completed without crashes. 
- Static/diagnostic checks: ran existing CI linters and assertions enabled in debug paths and observed no new assertion failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318fd2223c832590d172cebcc55ca9)