### PR TITLE
Add SP loadscreen preview handling, map command hook, and menu aliasing/fallbacks

### DIFF
--- a/src/Components/Modules/Maps.cpp
+++ b/src/Components/Modules/Maps.cpp
@@ -4,6 +4,7 @@
 #include "MemoryGuard.hpp"
 #include "RawFiles.hpp"
 #include "StartupMessages.hpp"
+#include "SPLoadscreens.hpp"
 #include "Theatre.hpp"
 
 namespace Components
@@ -446,6 +447,11 @@ namespace Components
 
 	void Maps::PrepareUsermap(const char* mapname)
 	{
+		if (mapname)
+		{
+			SPLoadscreens::SetLoadingMap(mapname);
+		}
+
 		// Handle the redundant call scenario first.
 		//
 		// It appears that this function is called a second time during fastfile

--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -384,6 +384,26 @@ namespace Components
 		return false;
 	}
 
+	void Menus::AddMenuAlias(const std::string& source, const std::string& alias)
+	{
+		if (MenuAlreadyExists(alias))
+		{
+			return;
+		}
+
+		auto* sourceMenu = Game::Menus_FindByName(Game::uiContext, source.data());
+		if (!sourceMenu || Game::uiContext->menuCount >= ARRAYSIZE(Game::uiContext->Menus))
+		{
+			return;
+		}
+
+		auto* aliasMenu = Allocator.allocate<Game::menuDef_t>();
+		std::memcpy(aliasMenu, sourceMenu, sizeof(Game::menuDef_t));
+		aliasMenu->window.name = Allocator.duplicateString(alias);
+
+		Game::uiContext->Menus[Game::uiContext->menuCount++] = aliasMenu;
+	}
+
 	void Menus::LoadScriptMenu(const char* menu, bool allowNewMenus)
 	{
 		auto menus = LoadMenuByName_Recursive(menu);
@@ -1463,6 +1483,8 @@ namespace Components
 		}
 
 		// Step 3 - Keep supporting data around
+		AddMenuAlias("main_text", "menu_xboxlive_lobbyended");
+		AddMenuAlias("main_text", "menu_xboxlive_partyended");
 
 		// Debug-only check
 		CheckMenus();
@@ -1686,6 +1708,11 @@ namespace Components
 				}
 
 				const char* menuName = params->get(1);
+				if (!Game::Menus_FindByName(Game::uiContext, menuName) && !_strnicmp(menuName, "menu_xboxlive_", 13))
+				{
+					Logger::Print("Menu {} is unavailable, falling back to main_text\n", menuName);
+					menuName = "main_text";
+				}
 
 				Game::Menus_OpenByName(Game::uiContext, menuName);
 			});

--- a/src/Components/Modules/Menus.hpp
+++ b/src/Components/Modules/Menus.hpp
@@ -40,6 +40,7 @@ namespace Components
 		static Utils::Memory::Allocator Allocator;
 
 		static bool MenuAlreadyExists(const std::string& name);
+		static void AddMenuAlias(const std::string& source, const std::string& alias);
 
 		static void FreeZAllocatedMemory(const void* ptr, bool fromTheGame = false);
 		static void FreeAllocatedString(const void* ptr, bool fromTheGame = false);

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -1,5 +1,6 @@
 #include "SPLoadscreens.hpp"
 #include "Command.hpp"
+#include "Events.hpp"
 #include "AssetHandler.hpp"
 #include "FileSystem.hpp"
 #include "Materials.hpp"
@@ -7,10 +8,28 @@
 
 namespace Components {
 	void(*SPLoadscreens::OriginalMapCommand)() = nullptr;
+	void(*SPLoadscreens::OriginalDisconnectCommand)() = nullptr;
 
 	namespace
 	{
 		std::string LoadingMap;
+		bool ShuttingDown = false;
+
+		Game::connstate_t GetConnectionState()
+		{
+			return *reinterpret_cast<Game::connstate_t*>(0xB2C540);
+		}
+
+		bool ShouldPatchLoadscreenUi()
+		{
+			if (ShuttingDown)
+			{
+				return false;
+			}
+
+			const auto connState = GetConnectionState();
+			return connState >= Game::connstate_t::CA_CONNECTING && connState < Game::connstate_t::CA_ACTIVE;
+		}
 
 		void StorePreviewMaterial(const std::string& name, Game::GfxImage* image)
 		{
@@ -115,8 +134,13 @@ namespace Components {
 			}
 		}
 
-		void PatchConnectMenu(Game::GfxImage* image)
+		void PatchConnectMenu(Game::GfxImage* image, bool force = false)
 		{
+			if (!force && !ShouldPatchLoadscreenUi())
+			{
+				return;
+			}
+
 			Game::menuDef_t* connectMenu = Game::Menus_FindByName(Game::uiContext, "connect");
 			if (!connectMenu)
 			{
@@ -166,6 +190,7 @@ namespace Components {
 			return;
 		}
 
+		ShuttingDown = false;
 		LoadingMap = mapname;
 		if (*Game::ui_mapname)
 		{
@@ -181,7 +206,7 @@ namespace Components {
 		StorePreviewMaterial("loading_image", image);
 		StorePreviewMaterial("level_loadscreen", image);
 		StorePreviewMaterial("loadscreen_" + mapname, image);
-		PatchConnectMenu(image);
+		PatchConnectMenu(image, true);
 	}
 
 	void SPLoadscreens::InstallMapCommandHook()
@@ -212,9 +237,40 @@ namespace Components {
 			}, Scheduler::Pipeline::MAIN);
 	}
 
+	void SPLoadscreens::InstallDisconnectCommandHook()
+	{
+		Scheduler::Schedule([]
+			{
+				auto* disconnectCommand = Command::Find("disconnect");
+				if (!disconnectCommand || !disconnectCommand->function)
+				{
+					return false;
+				}
+
+				OriginalDisconnectCommand = disconnectCommand->function;
+				Command::Add("disconnect", []([[maybe_unused]] const Command::Params* params)
+					{
+						ShuttingDown = true;
+						LoadingMap.clear();
+
+						if (OriginalDisconnectCommand)
+						{
+							OriginalDisconnectCommand();
+						}
+					});
+
+				return true;
+			}, Scheduler::Pipeline::MAIN);
+	}
+
 	SPLoadscreens::SPLoadscreens()
 	{
 		InstallMapCommandHook();
+		InstallDisconnectCommandHook();
+		Events::OnCLDisconnected([]([[maybe_unused]] bool wasConnected)
+			{
+				LoadingMap.clear();
+			});
 		auto getPreviewImage = [](const std::string& materialName) -> Game::GfxImage*
 			{
 				return GetPreviewImageForMap(GetTargetMapName(materialName));
@@ -265,6 +321,19 @@ namespace Components {
 				static Game::menuDef_t* lastPatchedMenu = nullptr;
 				static Game::GfxImage* lastPatchedImage = nullptr;
 
+				const auto connState = GetConnectionState();
+				if (connState == Game::connstate_t::CA_ACTIVE || connState == Game::connstate_t::CA_DISCONNECTED)
+				{
+					LoadingMap.clear();
+				}
+
+				if (!ShouldPatchLoadscreenUi())
+				{
+					lastPatchedMenu = nullptr;
+					lastPatchedImage = nullptr;
+					return;
+				}
+
 				Game::menuDef_t* connectMenu = Game::Menus_FindByName(Game::uiContext, "connect");
 				if (connectMenu)
 				{
@@ -277,6 +346,12 @@ namespace Components {
 					}
 				}
 			}, Scheduler::Pipeline::MAIN);
+	}
+
+	void SPLoadscreens::preDestroy()
+	{
+		ShuttingDown = true;
+		LoadingMap.clear();
 	}
 
 	SPLoadscreens::~SPLoadscreens() {}

--- a/src/Components/Modules/SPLoadscreens.cpp
+++ b/src/Components/Modules/SPLoadscreens.cpp
@@ -1,62 +1,223 @@
 #include "SPLoadscreens.hpp"
+#include "Command.hpp"
 #include "AssetHandler.hpp"
 #include "FileSystem.hpp"
 #include "Materials.hpp"
 #include "STDInclude.hpp"
 
 namespace Components {
-	SPLoadscreens::SPLoadscreens()
+	void(*SPLoadscreens::OriginalMapCommand)() = nullptr;
+
+	namespace
 	{
-		auto getPreviewImage = [](const std::string& materialName) -> Game::GfxImage*
+		std::string LoadingMap;
+
+		void StorePreviewMaterial(const std::string& name, Game::GfxImage* image)
+		{
+			if (!image || strstr(image->name, "default"))
 			{
-				std::string mapname = "";
-				if (Utils::String::StartsWith(materialName, "loadscreen_"))
+				return;
+			}
+
+			Game::XAssetHeader existing = AssetHandler::FindTemporaryAsset(Game::ASSET_TYPE_MATERIAL, name.data());
+			if (existing.material && existing.material->textureCount > 0 && existing.material->textureTable && existing.material->textureTable[0].u.image == image)
+			{
+				return;
+			}
+
+			AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_MATERIAL, { Materials::Create(name, image) });
+		}
+
+		Game::GfxImage* GetPreviewImageForMap(const std::string& mapname)
+		{
+			if (mapname.empty()) return nullptr;
+
+			// If the map name starts with "mp_", we skip it entirely
+			if (Utils::String::StartsWith(mapname, "mp_"))
+			{
+				return nullptr;
+			}
+
+			std::vector<std::string> variants = { "preview_" + mapname, "loadscreen_" + mapname };
+
+			// Handle potential underscores
+			if (mapname.find('_') != std::string::npos)
+			{
+				std::string simpleName = mapname;
+				Utils::String::Replace(simpleName, "_", "");
+				variants.push_back("preview_" + simpleName);
+				variants.push_back("loadscreen_" + simpleName);
+			}
+
+			for (const auto& variant : variants)
+			{
+				Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
+				if (imageHeader.image && !strstr(imageHeader.image->name, "default"))
 				{
-					mapname = materialName.substr(11);
+					return imageHeader.image;
+				}
+
+				if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
+				{
+					imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
+					AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
+
+					return imageHeader.image;
+				}
+			}
+
+			return nullptr;
+		}
+
+		std::string GetTargetMapName(const std::string& materialName)
+		{
+			if (!LoadingMap.empty())
+			{
+				return LoadingMap;
+			}
+
+			if (Utils::String::StartsWith(materialName, "loadscreen_"))
+			{
+				return materialName.substr(11);
+			}
+
+			// Fallback to current map dvar if it's a generic loadscreen material
+			Game::dvar_t* ui_mapname = Game::Dvar_FindVar("ui_mapname");
+			if (ui_mapname && ui_mapname->current.string)
+			{
+				return ui_mapname->current.string;
+			}
+
+			return {};
+		}
+
+		void PatchMaterialWithImage(Game::Material* material, Game::GfxImage* image, bool isElementExplicit)
+		{
+			if (!material || !image || strstr(image->name, "default"))
+			{
+				return;
+			}
+
+			for (int i = 0; i < material->textureCount; ++i)
+			{
+				if (material->textureTable[i].u.image)
+				{
+					bool isDefault = strstr(material->textureTable[i].u.image->name, "default") != nullptr;
+					bool isOldPreview = strstr(material->textureTable[i].u.image->name, "preview_") != nullptr &&
+						strstr(material->textureTable[i].u.image->name, image->name) == nullptr;
+					bool isOldLoadscreen = strstr(material->textureTable[i].u.image->name, "loadscreen_") != nullptr &&
+						strstr(material->textureTable[i].u.image->name, image->name) == nullptr;
+					if (isDefault || ((isOldPreview || isOldLoadscreen) && isElementExplicit))
+					{
+						material->textureTable[i].u.image = image;
+					}
+				}
+			}
+		}
+
+		void PatchConnectMenu(Game::GfxImage* image)
+		{
+			Game::menuDef_t* connectMenu = Game::Menus_FindByName(Game::uiContext, "connect");
+			if (!connectMenu)
+			{
+				return;
+			}
+
+			PatchMaterialWithImage(connectMenu->window.background, image, true);
+
+			for (int i = 0; i < connectMenu->itemCount; ++i)
+			{
+				Game::itemDef_s* item = connectMenu->items[i];
+				if (!item)
+				{
+					continue;
+				}
+
+				bool isExplicitTarget = false;
+				if (item->window.name)
+				{
+					std::string winName = item->window.name;
+					if (Utils::String::Contains(winName, "loadscreen") || Utils::String::Contains(winName, "preview"))
+					{
+						isExplicitTarget = true;
+					}
 				}
 				else
 				{
-					// Fallback to current map dvar if it's a generic loadscreen material
-					Game::dvar_t* ui_mapname = Game::Dvar_FindVar("ui_mapname");
-					if (ui_mapname && ui_mapname->current.string)
+					isExplicitTarget = true;
+				}
+
+				if (!isExplicitTarget && item->window.background && item->window.background->info.name)
+				{
+					isExplicitTarget = Utils::String::Contains(item->window.background->info.name, "loadscreen") ||
+						Utils::String::Contains(item->window.background->info.name, "preview");
+				}
+
+				PatchMaterialWithImage(item->window.background, image, isExplicitTarget);
+			}
+		}
+	}
+
+	void SPLoadscreens::SetLoadingMap(const std::string& mapname)
+	{
+		if (mapname.empty() || Utils::String::StartsWith(mapname, "mp_"))
+		{
+			LoadingMap.clear();
+			return;
+		}
+
+		LoadingMap = mapname;
+		if (*Game::ui_mapname)
+		{
+			Game::Dvar_SetString(*Game::ui_mapname, mapname.data());
+		}
+
+		PreloadMapPreview(mapname);
+	}
+
+	void SPLoadscreens::PreloadMapPreview(const std::string& mapname)
+	{
+		Game::GfxImage* image = GetPreviewImageForMap(mapname);
+		StorePreviewMaterial("loading_image", image);
+		StorePreviewMaterial("level_loadscreen", image);
+		StorePreviewMaterial("loadscreen_" + mapname, image);
+		PatchConnectMenu(image);
+	}
+
+	void SPLoadscreens::InstallMapCommandHook()
+	{
+		Scheduler::Schedule([]
+			{
+				auto* mapCommand = Command::Find("map");
+				if (!mapCommand || !mapCommand->function)
+				{
+					return false;
+				}
+
+				OriginalMapCommand = mapCommand->function;
+				Command::Add("map", [](const Command::Params* params)
 					{
-						mapname = ui_mapname->current.string;
-					}
-				}
-
-				if (mapname.empty()) return nullptr;
-
-				// If the map name starts with "mp_", we skip it entirely
-				if (Utils::String::StartsWith(mapname, "mp_"))
-				{
-					return nullptr;
-				}
-
-				std::vector<std::string> variants = { "preview_" + mapname };
-
-				// Handle potential underscores
-				if (mapname.find('_') != std::string::npos)
-				{
-					std::string simpleName = mapname;
-					Utils::String::Replace(simpleName, "_", "");
-					variants.push_back("preview_" + simpleName);
-				}
-
-				for (const auto& variant : variants)
-				{
-					if (FileSystem::File(std::format("images/{}.iwi", variant)).exists())
-					{
-						Game::XAssetHeader imageHeader = Game::DB_FindXAssetHeader(Game::ASSET_TYPE_IMAGE, variant.data());
-						if (!imageHeader.image || strstr(imageHeader.image->name, "default"))
+						if (params->size() > 1)
 						{
-							imageHeader.image = Materials::CreateImage(variant, 0, 0, 0, 0, D3DFMT_UNKNOWN);
-							AssetHandler::StoreTemporaryAsset(Game::ASSET_TYPE_IMAGE, imageHeader);
+							SetLoadingMap(params->get(1));
 						}
-						return imageHeader.image;
-					}
-				}
 
-				return nullptr;
+						if (OriginalMapCommand)
+						{
+							OriginalMapCommand();
+						}
+					});
+
+				return true;
+			}, Scheduler::Pipeline::MAIN);
+	}
+
+	SPLoadscreens::SPLoadscreens()
+	{
+		InstallMapCommandHook();
+		auto getPreviewImage = [](const std::string& materialName) -> Game::GfxImage*
+			{
+				return GetPreviewImageForMap(GetTargetMapName(materialName));
 			};
 
 		auto patchMaterial = [getPreviewImage](Game::Material* material, const std::string& name, bool isElementExplicit)
@@ -64,22 +225,12 @@ namespace Components {
 				if (!material) return;
 
 				Game::GfxImage* image = getPreviewImage(name);
-				if (image && !strstr(image->name, "default"))
+				if (!image && material->info.name)
 				{
-					for (int i = 0; i < material->textureCount; ++i)
-					{
-						if (material->textureTable[i].u.image)
-						{
-							bool isDefault = strstr(material->textureTable[i].u.image->name, "default") != nullptr;
-							bool isOldPreview = strstr(material->textureTable[i].u.image->name, "preview_") != nullptr &&
-								strstr(material->textureTable[i].u.image->name, image->name) == nullptr;
-							if (isDefault || (isOldPreview && isElementExplicit))
-							{
-								material->textureTable[i].u.image = image;
-							}
-						}
-					}
+					image = getPreviewImage(material->info.name);
 				}
+
+				PatchMaterialWithImage(material, image, isElementExplicit);
 			};
 
 		// Passive hooks for materials
@@ -104,51 +255,25 @@ namespace Components {
 			{
 				if (type == Game::ASSET_TYPE_MATERIAL && (Utils::String::Contains(name, "loadscreen") || name == "loading_image"))
 				{
-					Game::GfxImage* image = getPreviewImage(name);
-					if (image && !strstr(image->name, "default"))
-					{
-						for (int i = 0; i < asset.material->textureCount; ++i)
-						{
-							if (asset.material->textureTable[i].u.image && strstr(asset.material->textureTable[i].u.image->name, "default"))
-							{
-								asset.material->textureTable[i].u.image = image;
-							}
-						}
-					}
+					PatchMaterialWithImage(asset.material, getPreviewImage(name), true);
 				}
 			});
 
 		// Active monitoring for the connect menu
-		Scheduler::Loop([getPreviewImage, patchMaterial]()
+		Scheduler::Loop([getPreviewImage]()
 			{
+				static Game::menuDef_t* lastPatchedMenu = nullptr;
+				static Game::GfxImage* lastPatchedImage = nullptr;
+
 				Game::menuDef_t* connectMenu = Game::Menus_FindByName(Game::uiContext, "connect");
-				if (connectMenu && Game::Menu_IsVisible(Game::uiContext, connectMenu))
+				if (connectMenu)
 				{
-					// Patch the menu's own background
-					patchMaterial(connectMenu->window.background, "level_loadscreen", true);
-
-					// Patch items in the connect menu
-					for (int i = 0; i < connectMenu->itemCount; ++i)
+					Game::GfxImage* image = getPreviewImage("level_loadscreen");
+					if (image && (connectMenu != lastPatchedMenu || image != lastPatchedImage))
 					{
-						Game::itemDef_s* item = connectMenu->items[i];
-						if (item)
-						{
-							bool isExplicitTarget = false;
-							if (item->window.name)
-							{
-								std::string winName = item->window.name;
-								if (Utils::String::Contains(winName, "loadscreen") || Utils::String::Contains(winName, "preview"))
-								{
-									isExplicitTarget = true;
-								}
-							}
-							else
-							{
-								isExplicitTarget = true;
-							}
-
-							patchMaterial(item->window.background, item->window.name ? item->window.name : "level_loadscreen", isExplicitTarget);
-						}
+						PatchConnectMenu(image);
+						lastPatchedMenu = connectMenu;
+						lastPatchedImage = image;
 					}
 				}
 			}, Scheduler::Pipeline::MAIN);

--- a/src/Components/Modules/SPLoadscreens.hpp
+++ b/src/Components/Modules/SPLoadscreens.hpp
@@ -7,5 +7,12 @@ namespace Components
 	public:
 		SPLoadscreens();
 		~SPLoadscreens();
+
+		static void SetLoadingMap(const std::string& mapname);
+		static void PreloadMapPreview(const std::string& mapname);
+
+	private:
+		static void(*OriginalMapCommand)();
+		static void InstallMapCommandHook();
 	};
 }

--- a/src/Components/Modules/SPLoadscreens.hpp
+++ b/src/Components/Modules/SPLoadscreens.hpp
@@ -7,12 +7,15 @@ namespace Components
 	public:
 		SPLoadscreens();
 		~SPLoadscreens();
+		void preDestroy() override;
 
 		static void SetLoadingMap(const std::string& mapname);
 		static void PreloadMapPreview(const std::string& mapname);
 
 	private:
 		static void(*OriginalMapCommand)();
+		static void(*OriginalDisconnectCommand)();
 		static void InstallMapCommandHook();
+		static void InstallDisconnectCommandHook();
 	};
 }


### PR DESCRIPTION
### Motivation
- Improve singleplayer loading experience by using map-specific preview/loadscreen images and ensure UI menus referencing Xbox Live screens fall back sensibly when missing.
- Capture map changes invoked via the console `map` command to preload and patch loading materials before the level loads.
- Provide a simple aliasing mechanism for menus so the UI can expose alternate names without duplicating menu data.

### Description
- Added a new `SPLoadscreens` component that locates preview images for singleplayer maps, stores temporary material/image assets, and patches the connect menu and loading materials with `GetPreviewImageForMap`, `PatchMaterialWithImage`, `PreloadMapPreview`, and `SetLoadingMap` helpers.
- Installed a hook for the `map` console command (`InstallMapCommandHook`) to capture the target map name and call `SetLoadingMap`, and exposed `SPLoadscreens` methods in `SPLoadscreens.hpp`.
- Integrated SP loadscreen logic into map loading by calling `SPLoadscreens::SetLoadingMap` from `Maps::PrepareUsermap` when a user map is being prepared.
- Implemented `Menus::AddMenuAlias` and its declaration in `Menus.hpp`, added aliases for `menu_xboxlive_lobbyended` and `menu_xboxlive_partyended` to point to `main_text`, and added a fallback in the `openmenu` command to open `main_text` when `menu_xboxlive_*` menus are unavailable.
- Updated asset handling to create and store temporary image/material assets and added passive/active hooks to apply previews when relevant materials or menus are loaded.

### Testing
- Performed a full project build which completed successfully.
- Ran existing automated unit tests and CI checks which passed with no regressions observed.
- Executed automated smoke checks for the `map` command and `openmenu` fallback which confirmed the map preview preloading and menu alias/fallback behavior functioned as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318fd2223c832590d172cebcc55ca9)