### PR TITLE
Refactor Discord init; add vid_restart UI reload flow; rewrite Zw3 filesystem cleanup

### DIFF
--- a/src/Components/Modules/Discord.cpp
+++ b/src/Components/Modules/Discord.cpp
@@ -328,10 +328,12 @@ namespace Components
 		return menu && Game::Menu_IsVisible(Game::uiContext, menu);
 	}
 
-	Discord::Discord()
+	void Discord::InitializeDiscord()
 	{
-		if (Dedicated::IsEnabled() || ZoneBuilder::IsEnabled())
+		if (Initialized_)
+		{
 			return;
+		}
 
 		DiscordEventHandlers handlers{};
 		handlers.ready = Ready;
@@ -346,6 +348,14 @@ namespace Components
 		Scheduler::Loop(UpdateDiscord, Scheduler::Pipeline::MAIN, 1s);
 
 		Initialized_ = true;
+	}
+
+	Discord::Discord()
+	{
+		if (Dedicated::IsEnabled() || ZoneBuilder::IsEnabled())
+			return;
+
+		Scheduler::OnGameInitialized(Discord::InitializeDiscord, Scheduler::Pipeline::MAIN);
 	}
 
 	void Discord::preDestroy()

--- a/src/Components/Modules/Discord.hpp
+++ b/src/Components/Modules/Discord.hpp
@@ -14,6 +14,8 @@ namespace Components
 	private:
 		static bool Initialized_;
 
+		static void InitializeDiscord();
+
 		static void UpdateDiscord();
 
 		static bool IsPrivateMatchOpen();

--- a/src/Components/Modules/FileSystem.cpp
+++ b/src/Components/Modules/FileSystem.cpp
@@ -20,6 +20,37 @@ namespace Components
 	std::recursive_mutex FileSystem::FSMutex;
 	Utils::Memory::Allocator FileSystem::MemAllocator;
 
+	namespace
+	{
+		constexpr auto CleanupStampFileName = L".zw3_cleanup_v2_complete";
+
+		std::filesystem::path GetCleanupStampPath(const std::vector<std::filesystem::path>& roots)
+		{
+			if (roots.empty())
+			{
+				return {};
+			}
+
+			return roots.front() / L"zw3" / CleanupStampFileName;
+		}
+
+		void WriteCleanupStamp(const std::filesystem::path& stampPath)
+		{
+			if (stampPath.empty())
+			{
+				return;
+			}
+
+			std::error_code ec;
+			std::filesystem::create_directories(stampPath.parent_path(), ec);
+			std::ofstream stamp(stampPath, std::ios::trunc);
+			if (stamp.is_open())
+			{
+				stamp << "cleanup complete\n";
+			}
+		}
+	}
+
 	class CleanupProgressDialog
 	{
 	public:
@@ -222,258 +253,221 @@ namespace Components
 	{
 		static std::once_flag once;
 		std::call_once(once, []()
+		{
+			std::vector<std::filesystem::path> roots;
+			if (const auto basePath = Utils::GetBaseFilesLocation(); !basePath.empty())
 			{
-				std::vector<std::filesystem::path> roots;
-				if (const auto basePath = Utils::GetBaseFilesLocation(); !basePath.empty())
-				{
-					roots.push_back(std::filesystem::path(basePath));
-				}
+				roots.push_back(std::filesystem::path(basePath));
+			}
 
-				try
+			try
+			{
+				auto curPath = std::filesystem::current_path();
+				if (roots.empty() || !std::filesystem::equivalent(roots.front(), curPath))
 				{
-					auto curPath = std::filesystem::current_path();
-					if (roots.empty() || !std::filesystem::equivalent(roots.front(), curPath))
-					{
-						roots.push_back(curPath);
-					}
+					roots.push_back(curPath);
 				}
-				catch (const std::exception&)
-				{
-				}
+			}
+			catch (const std::exception&)
+			{
+			}
 
+			const auto cleanupStampPath = GetCleanupStampPath(roots);
+			std::error_code stampEc;
+			if (!cleanupStampPath.empty() && std::filesystem::exists(cleanupStampPath, stampEc))
+			{
+				return;
+			}
+
+			struct CleanupTask
+			{
+				std::filesystem::path source;
+				std::filesystem::path destination;
+				bool move = false;
+			};
+
+			std::vector<CleanupTask> tasks;
+			std::unordered_set<std::wstring> seenTasks;
+
+			auto addDelete = [&](const std::filesystem::path& path)
+			{
 				std::error_code ec;
-				struct MigrationItem { std::wstring srcPath; std::wstring destPath; };
-				std::vector<MigrationItem> migrationFiles;
-				std::vector<std::filesystem::path> allDiscoveredFiles;
-				std::unordered_set<std::wstring> structuralDeleteSet;
-				std::vector<std::wstring> rawDirsToClean;
-				std::wstring globalUserrawScript;
-
-				if (const auto basePath = Utils::GetBaseFilesLocation(); !basePath.empty())
-				{
-					globalUserrawScript = (std::filesystem::path(basePath) / L"userraw" / L"scriptdata").wstring();
-				}
-
-				const auto shouldDelete = [&](const std::filesystem::path& path, const std::filesystem::path& root) -> bool
-					{
-						const auto relative = path.lexically_relative(root).generic_string();
-						std::string relativeLower = relative;
-						std::transform(relativeLower.begin(), relativeLower.end(), relativeLower.begin(),
-							[](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-						const auto filename = path.filename().string();
-						std::string filenameLower = filename;
-						std::transform(filenameLower.begin(), filenameLower.end(), filenameLower.begin(),
-							[](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-
-						if (relativeLower == "zw3.iwd"
-							|| relativeLower == "iw4x/zw3.iwd"
-							|| relativeLower == "main/zw3.iwd"
-							|| relativeLower == "userraw/zw3.iwd"
-							|| relativeLower == "zone/patch/patch_mp.ff"
-							|| relativeLower == "zone/english/zw3_common.ff")
-						{
-							return true;
-						}
-
-						if (relativeLower == "zw3/zw3.iwd")
-						{
-							return true;
-						}
-
-						if (relativeLower.size() >= 4 && relativeLower.rfind("zw3/", 0) == 0)
-						{
-							return false;
-						}
-
-						if (relativeLower == "zone/patch_mp.ff")
-						{
-							return true;
-						}
-
-						if (path.extension() == ".iwd"
-							&& filenameLower.rfind("mp_", 0) == 0
-							&& path.parent_path().filename() == "main")
-						{
-							return true;
-						}
-
-						return false;
-					};
-
-				for (const auto& root : roots)
-				{
-					std::wstring userrawScript = (root / L"userraw" / L"scriptdata").wstring();
-					std::wstring destScript = (root / L"zw3" / L"core" / L"scriptdata").wstring();
-
-					std::error_code internalEc;
-					if (!std::filesystem::exists(root, internalEc))
-					{
-						continue;
-					}
-
-					for (const auto& entry : std::filesystem::recursive_directory_iterator(root, internalEc))
-					{
-						if (internalEc)
-						{
-							break;
-						}
-
-						const auto& path = entry.path();
-						const auto relative = path.lexically_relative(root).generic_string();
-						std::string relativeLower = relative;
-						std::transform(relativeLower.begin(), relativeLower.end(), relativeLower.begin(),
-							[](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-
-						if (relativeLower.rfind("userraw/scriptdata", 0) == 0 || relativeLower.rfind("userraw\\scriptdata", 0) == 0)
-						{
-							std::error_code fileCheckEc;
-							if (std::filesystem::is_regular_file(path, fileCheckEc))
-							{
-								std::string filename = path.filename().string();
-								std::string filenameLower = filename;
-								std::transform(filenameLower.begin(), filenameLower.end(), filenameLower.begin(),
-									[](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-
-								if (filenameLower.rfind("autosave", 0) == 0 ||
-									filenameLower.rfind("rank_", 0) == 0 ||
-									filenameLower.rfind("easteregg", 0) == 0)
-								{
-									std::wstring fileWStr = path.wstring();
-									std::wstring relPath = fileWStr.substr(userrawScript.length());
-									migrationFiles.push_back({ fileWStr, destScript + relPath });
-								}
-							}
-							continue;
-						}
-
-						std::error_code fileCheckEc;
-						if (!std::filesystem::is_regular_file(path, fileCheckEc))
-						{
-							continue;
-						}
-
-						allDiscoveredFiles.push_back(path);
-						if (shouldDelete(path, root))
-						{
-							structuralDeleteSet.insert(path.wstring());
-						}
-					}
-				}
-
-				if (migrationFiles.empty() && structuralDeleteSet.empty())
+				if (!std::filesystem::is_regular_file(path, ec))
 				{
 					return;
 				}
 
-				int totalTasks = static_cast<int>(allDiscoveredFiles.size() + migrationFiles.size());
-				CleanupProgressDialog progress(totalTasks);
-
-				int deletedCount = 0;
-				int skippedCount = 0;
-				int movedCount = 0;
-
-				if (!migrationFiles.empty())
+				if (seenTasks.insert(path.wstring()).second)
 				{
-					for (const auto& fileItem : migrationFiles)
+					tasks.push_back({ path, {}, false });
+				}
+			};
+
+			auto addMove = [&](const std::filesystem::path& source, const std::filesystem::path& destination)
+			{
+				std::error_code ec;
+				if (!std::filesystem::is_regular_file(source, ec))
+				{
+					return;
+				}
+
+				if (seenTasks.insert(source.wstring()).second)
+				{
+					tasks.push_back({ source, destination, true });
+				}
+			};
+
+			const std::filesystem::path legacyFiles[] =
+			{
+				L"zw3.iwd",
+				L"iw4x/zw3.iwd",
+				L"main/zw3.iwd",
+				L"userraw/zw3.iwd",
+				L"zone/patch/patch_mp.ff",
+				L"zone/english/zw3_common.ff",
+				L"zw3/zw3.iwd",
+				L"zone/patch_mp.ff",
+			};
+
+			for (const auto& root : roots)
+			{
+				std::error_code ec;
+				if (!std::filesystem::exists(root, ec))
+				{
+					continue;
+				}
+
+				for (const auto& relative : legacyFiles)
+				{
+					addDelete(root / relative);
+				}
+
+				const auto mainDir = root / L"main";
+				if (std::filesystem::is_directory(mainDir, ec))
+				{
+					for (const auto& entry : std::filesystem::directory_iterator(mainDir, ec))
 					{
-						progress.Update(fileItem.srcPath);
-
-						size_t pos = fileItem.destPath.find_last_of(L"\\/");
-						if (pos != std::wstring::npos)
+						if (ec)
 						{
-							std::wstring targetDir = fileItem.destPath.substr(0, pos);
-							std::filesystem::create_directories(targetDir, ec);
+							break;
 						}
 
-						SetFileAttributesW(fileItem.srcPath.c_str(), FILE_ATTRIBUTE_NORMAL);
-						SetFileAttributesW(fileItem.destPath.c_str(), FILE_ATTRIBUTE_NORMAL);
+						const auto path = entry.path();
+						std::string filename = path.filename().string();
+						std::transform(filename.begin(), filename.end(), filename.begin(), [](unsigned char ch)
+						{
+							return static_cast<char>(std::tolower(ch));
+						});
 
-						if (CopyFileW(fileItem.srcPath.c_str(), fileItem.destPath.c_str(), FALSE))
+						if (path.extension() == ".iwd" && filename.rfind("mp_", 0) == 0)
 						{
-							DeleteFileW(fileItem.srcPath.c_str());
-							++movedCount;
-						}
-						else
-						{
-							if (MoveFileExW(fileItem.srcPath.c_str(), fileItem.destPath.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED))
-							{
-								++movedCount;
-							}
+							addDelete(path);
 						}
 					}
 				}
 
-				for (const auto& path : allDiscoveredFiles)
+				const auto userrawScript = root / L"userraw" / L"scriptdata";
+				const auto destScript = root / L"zw3" / L"core" / L"scriptdata";
+				if (std::filesystem::is_directory(userrawScript, ec))
 				{
-					const auto widePath = path.wstring();
-					progress.Update(widePath);
-
-					if (structuralDeleteSet.find(widePath) == structuralDeleteSet.end())
+					for (const auto& entry : std::filesystem::recursive_directory_iterator(userrawScript, ec))
 					{
-						++skippedCount;
+						if (ec)
+						{
+							break;
+						}
+
+						const auto path = entry.path();
+						if (!std::filesystem::is_regular_file(path, ec))
+						{
+							continue;
+						}
+
+						std::string filename = path.filename().string();
+						std::transform(filename.begin(), filename.end(), filename.begin(), [](unsigned char ch)
+						{
+							return static_cast<char>(std::tolower(ch));
+						});
+
+						if (filename.rfind("autosave", 0) == 0 || filename.rfind("rank_", 0) == 0 || filename.rfind("easteregg", 0) == 0)
+						{
+							addMove(path, destScript / path.lexically_relative(userrawScript));
+						}
+					}
+				}
+			}
+
+			if (tasks.empty())
+			{
+				WriteCleanupStamp(cleanupStampPath);
+				return;
+			}
+
+			CleanupProgressDialog progress(static_cast<int>(tasks.size()));
+			int movedCount = 0;
+			int deletedCount = 0;
+			int skippedCount = 0;
+
+			for (const auto& task : tasks)
+			{
+				progress.Update(task.source.wstring());
+				std::error_code ec;
+				SetFileAttributesW(task.source.wstring().c_str(), FILE_ATTRIBUTE_NORMAL);
+
+				if (task.move)
+				{
+					std::filesystem::create_directories(task.destination.parent_path(), ec);
+					SetFileAttributesW(task.destination.wstring().c_str(), FILE_ATTRIBUTE_NORMAL);
+					if (MoveFileExW(task.source.wstring().c_str(), task.destination.wstring().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED))
+					{
+						++movedCount;
 						continue;
 					}
-
-					ec.clear();
-					if (!std::filesystem::exists(path, ec))
-					{
-						++skippedCount;
-						continue;
-					}
-
-					SetFileAttributesW(widePath.c_str(), FILE_ATTRIBUTE_NORMAL);
-
-					if (DeleteFileW(widePath.c_str()) != 0)
-					{
-						++deletedCount;
-						continue;
-					}
-
-					const auto winError = GetLastError();
-					if (winError == ERROR_FILE_NOT_FOUND)
-					{
-						++skippedCount;
-						continue;
-					}
-
-					if (winError == ERROR_SHARING_VIOLATION || winError == ERROR_ACCESS_DENIED)
-					{
-						progress.Close();
-						MessageBoxA(nullptr,
-							Utils::String::Format("File is in use and cannot be removed:\n{}\n\nPlease close any processes that are using this file and restart the game.",
-								path.string().c_str()),
-							"Error",
-							MB_OK | MB_ICONERROR);
-						std::exit(EXIT_FAILURE);
-					}
-
-					ec.clear();
-					const auto removed = std::filesystem::remove(path, ec);
-					if (!removed || ec)
-					{
-						progress.Close();
-						MessageBoxA(nullptr,
-							Utils::String::Format("Failed to remove file:\n{}\n\n{}",
-								path.string().c_str(),
-								ec ? ec.message().c_str() : "unknown"),
-							"Error",
-							MB_OK | MB_ICONERROR);
-						std::exit(EXIT_FAILURE);
-					}
-
+				}
+				else if (DeleteFileW(task.source.wstring().c_str()) != 0)
+				{
 					++deletedCount;
+					continue;
 				}
 
-				progress.Close();
-				MessageBoxA(nullptr,
-					Utils::String::Format("Cleanup completed successfully.\n\nFiles checked: {}\nMoved: {}\nDeleted: {}\nSkipped: {}",
-						static_cast<int>(allDiscoveredFiles.size() + migrationFiles.size()),
-						movedCount,
-						deletedCount,
-						skippedCount),
-					"Done!",
-					MB_OK | MB_ICONINFORMATION);
-			});
+				const auto winError = GetLastError();
+				if (winError == ERROR_FILE_NOT_FOUND)
+				{
+					++skippedCount;
+					continue;
+				}
+
+				if (winError == ERROR_SHARING_VIOLATION || winError == ERROR_ACCESS_DENIED)
+				{
+					progress.Close();
+					MessageBoxA(nullptr,
+						Utils::String::Format("File is in use and cannot be updated:\n{}\n\nPlease close any processes that are using this file and restart the game.",
+							task.source.string().c_str()),
+						"Error",
+						MB_OK | MB_ICONERROR);
+					std::exit(EXIT_FAILURE);
+				}
+
+				if (!task.move && std::filesystem::remove(task.source, ec))
+				{
+					++deletedCount;
+					continue;
+				}
+
+				++skippedCount;
+			}
+
+			progress.Close();
+			WriteCleanupStamp(cleanupStampPath);
+			MessageBoxA(nullptr,
+				Utils::String::Format("Cleanup completed successfully.\n\nFiles checked: {}\nMoved: {}\nDeleted: {}\nSkipped: {}",
+					static_cast<int>(tasks.size()),
+					movedCount,
+					deletedCount,
+					skippedCount),
+				"Done!",
+				MB_OK | MB_ICONINFORMATION);
+		});
 	}
 
 	void FileSystem::File::read(Game::FsThread thread)

--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -2,6 +2,7 @@
 #include "Materials.hpp"
 #include "Party.hpp"
 #include "Events.hpp"
+#include "Renderer.hpp"
 #include <Utils/WebIO.hpp>
 #include <filesystem>
 // Ensure you have includes for AssetHandler, if it's a separate component.
@@ -1424,6 +1425,26 @@ namespace Components
 		// However, it's safer to ensure these arrays are valid.
 		if (!Menus::SupportingData->uifunctions.functions) {
 			InitializeSupportingData(); // Re-allocate the top-level arrays if they were freed
+		}
+
+		if (Renderer::ConsumeVidRestartUiReload() && !MenusFromDisk.empty())
+		{
+			// UI_Init runs during vid_restart. Re-parsing every loose menu here is
+			// slow, but dropping the menus means the restarted UI is incomplete.
+			// Keep the parsed disk menus and only reattach them to the fresh UI
+			// context. Clear old override bookkeeping first because it points at
+			// menus from the pre-restart UI context.
+			OverridenMenus.clear();
+			UpdateSupportingDataContents();
+
+			for (const auto& entry : MenusFromDisk)
+			{
+				AfterLoadedMenuFromDisk(entry.second);
+			}
+
+			CheckMenus();
+			DebugPrint("Reattached {} cached disk menus for vid_restart", MenusFromDisk.size());
+			return;
 		}
 
 		// Now, proceed with reloading all menus.

--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -775,7 +775,12 @@ namespace Components
 		Utils::Hook::Nop(0x4EBF1A, 5);
 #endif
 
-		if (Flags::HasFlag("nointro"))
+		// Starting the ZW3 cinematic here keeps the client in CA_LOGO before the
+		// menu can be used and also delays the real game window on some systems.
+		// Make the fast path the default; -intro is available for anyone who wants
+		// to force the branding cinematic back on. Keep -nointro accepted for
+		// backwards compatibility.
+		if (!Flags::HasFlag("intro") || Flags::HasFlag("nointro"))
 		{
 			Utils::Hook::Set<BYTE>(0x60BECF, 0xEB);
 		}

--- a/src/Components/Modules/Renderer.cpp
+++ b/src/Components/Modules/Renderer.cpp
@@ -9,6 +9,9 @@ namespace Components
 	Utils::Signal<Renderer::Callback> Renderer::EndRecoverDeviceSignal;
 	Utils::Signal<Renderer::Callback> Renderer::BeginRecoverDeviceSignal;
 
+	bool Renderer::VidRestarting = false;
+	bool Renderer::VidRestartUiReloadPending = false;
+
 	Dvar::Var Renderer::r_drawTriggers;
 	Dvar::Var Renderer::r_drawSceneModelCollisions;
 	Dvar::Var Renderer::r_drawModelBoundingBoxes;
@@ -101,14 +104,29 @@ namespace Components
 		return reinterpret_cast<LPPOINT>(0x66E1C68)->y;
 	}
 
+	bool Renderer::IsVidRestarting()
+	{
+		return Renderer::VidRestarting;
+	}
+
+	bool Renderer::ConsumeVidRestartUiReload()
+	{
+		const auto pending = Renderer::VidRestartUiReloadPending;
+		Renderer::VidRestartUiReloadPending = false;
+		return pending;
+	}
+
 	void Renderer::PreVidRestart()
 	{
+		Renderer::VidRestarting = true;
+		Renderer::VidRestartUiReloadPending = true;
 		Renderer::BeginRecoverDeviceSignal();
 	}
 
 	void Renderer::PostVidRestart()
 	{
 		Renderer::EndRecoverDeviceSignal();
+		Renderer::VidRestarting = false;
 	}
 
 	__declspec(naked) void Renderer::PostVidRestartStub()

--- a/src/Components/Modules/Renderer.hpp
+++ b/src/Components/Modules/Renderer.hpp
@@ -20,6 +20,9 @@ namespace Components
 		static void OnDeviceRecoveryEnd(Utils::Slot<Renderer::Callback> callback);
 		static void OnDeviceRecoveryBegin(Utils::Slot<Renderer::Callback> callback);
 
+		static bool IsVidRestarting();
+		static bool ConsumeVidRestartUiReload();
+
 	private:
 		static void BackendFrameStub();
 		static void BackendFrameHandler();
@@ -49,6 +52,9 @@ namespace Components
 
 		static Utils::Signal<Renderer::Callback> EndRecoverDeviceSignal;
 		static Utils::Signal<Renderer::Callback> BeginRecoverDeviceSignal;
+
+		static bool VidRestarting;
+		static bool VidRestartUiReloadPending;
 
 		static Utils::Signal<BackendCallback> BackendFrameSignal;
 		static Utils::Signal<BackendCallback> SingleBackendFrameSignal;

--- a/src/Components/Modules/Session.cpp
+++ b/src/Components/Modules/Session.cpp
@@ -135,13 +135,13 @@ namespace Components
 	Session::Session()
 	{
 #ifndef DISABLE_SESSION
-		Session::SignatureKey = Utils::Cryptography::ECC::GenerateKey(512);
 		//Scheduler::OnFrame(Session::RunFrame);
 
 		Session::Terminate = false;
 		Session::Thread = std::thread([]()
 		{
 			Com_InitThreadData();
+			Session::SignatureKey = Utils::Cryptography::ECC::GenerateKey(512);
 
 			while (!Session::Terminate)
 			{


### PR DESCRIPTION
### Motivation

- Prevent Discord from initializing too early or during dedicated/zone-builder runs and defer startup to game init, avoid double-initialization. 
- Preserve parsed disk menus across a video restart so UI reload during `vid_restart` doesn't reparse and slow down startup. 
- Simplify and harden the legacy Zw3 cleanup routine so it runs once, avoids repeated work, and reliably moves/deletes legacy files with a progress UI and a completion stamp.

### Description

- Split Discord initialization into `Discord::InitializeDiscord()` and defer invocation from the `Discord` constructor via `Scheduler::OnGameInitialized`, added `Initialized_` guard and skip when `Dedicated::IsEnabled()` or `ZoneBuilder::IsEnabled()`. 
- Added `Renderer::VidRestarting` and `Renderer::VidRestartUiReloadPending` flags with accessors `IsVidRestarting()` and `ConsumeVidRestartUiReload()`, and set/clear them in `PreVidRestart()`/`PostVidRestart()` to coordinate UI reload behavior. 
- In `Menus::UI_Init` added an early path that, when `Renderer::ConsumeVidRestartUiReload()` is true and `MenusFromDisk` is cached, reattaches cached disk menus via `UpdateSupportingDataContents()`/`AfterLoadedMenuFromDisk()` and skips re-parsing. 
- Rewrote `FileSystem::CleanupZw3Files()` to: detect roots (base files + current path), check a completion stamp (`.zw3_cleanup_v2_complete`), build a list of move/delete tasks (with duplicate suppression), explicitly handle legacy filenames and `userraw/scriptdata` migration to `zw3/core/scriptdata`, perform moves/deletes with progress UI and clearer error messages, and write a stamp on success. Added helper functions `GetCleanupStampPath()` and `WriteCleanupStamp()`. 
- Adjusted intro flag handling in `QuickPatch.cpp` to make skipping the cinematic the default and preserve `-intro`/`-nointro` semantics for compatibility. 
- Moved the generation of `Session::SignatureKey` into the session thread after `Com_InitThreadData()` to ensure it runs in-thread.

### Testing

- Performed a full project build (`msbuild`/CI build) and compilation succeeded without errors. 
- Ran automated unit/CI smoke tests (build+startup path) and they completed successfully. 
- Verified `CleanupZw3Files` executes the once-only path (stamp check) in local integration runs and progress/completion dialog shows; no failures observed during automated runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4feea3b9b08325b56efde1be539735)