### PR TITLE
Defer heavy startup work, add splash screen, robust FS cleanup, and renderer vid-restart handling

### DIFF
--- a/src/Components/Loader.cpp
+++ b/src/Components/Loader.cpp
@@ -112,8 +112,6 @@ namespace Components
 		// High priority
 		Register(new Singleton());
 
-		FileSystem::CleanupZw3Files();
-
 		Register(new Auth());
 		Register(new Command());
 		Register(new Dvar());

--- a/src/Components/Modules/Auth.cpp
+++ b/src/Components/Modules/Auth.cpp
@@ -605,9 +605,11 @@ namespace Components
 
 		Localization::Set("MPUI_SECURITY_INCREASE_MESSAGE", "");
 
-		// Load the key
-		LoadKey(true);
-		Steam::SteamUser()->GetSteamID();
+		Scheduler::OnGameInitialized([]
+		{
+			LoadKey(true);
+			Steam::SteamUser()->GetSteamID();
+		}, Scheduler::Pipeline::MAIN);
 
 		Scheduler::Loop(Frame, Scheduler::Pipeline::MAIN);
 

--- a/src/Components/Modules/Discord.cpp
+++ b/src/Components/Modules/Discord.cpp
@@ -328,10 +328,12 @@ namespace Components
 		return menu && Game::Menu_IsVisible(Game::uiContext, menu);
 	}
 
-	Discord::Discord()
+	void Discord::InitializeDiscord()
 	{
-		if (Dedicated::IsEnabled() || ZoneBuilder::IsEnabled())
+		if (Initialized_)
+		{
 			return;
+		}
 
 		DiscordEventHandlers handlers{};
 		handlers.ready = Ready;
@@ -346,6 +348,14 @@ namespace Components
 		Scheduler::Loop(UpdateDiscord, Scheduler::Pipeline::MAIN, 1s);
 
 		Initialized_ = true;
+	}
+
+	Discord::Discord()
+	{
+		if (Dedicated::IsEnabled() || ZoneBuilder::IsEnabled())
+			return;
+
+		Scheduler::OnGameInitialized(Discord::InitializeDiscord, Scheduler::Pipeline::MAIN);
 	}
 
 	void Discord::preDestroy()

--- a/src/Components/Modules/Discord.hpp
+++ b/src/Components/Modules/Discord.hpp
@@ -14,6 +14,8 @@ namespace Components
 	private:
 		static bool Initialized_;
 
+		static void InitializeDiscord();
+
 		static void UpdateDiscord();
 
 		static bool IsPrivateMatchOpen();

--- a/src/Components/Modules/FileSystem.cpp
+++ b/src/Components/Modules/FileSystem.cpp
@@ -20,6 +20,42 @@ namespace Components
 	std::recursive_mutex FileSystem::FSMutex;
 	Utils::Memory::Allocator FileSystem::MemAllocator;
 
+	namespace
+	{
+		constexpr auto CleanupStampFileName = L".zw3_cleanup_v2_complete";
+
+		std::filesystem::path GetCleanupStampPath(const std::vector<std::filesystem::path>& roots)
+		{
+			if (roots.empty())
+			{
+				return {};
+			}
+
+			return roots.front() / L"zw3" / CleanupStampFileName;
+		}
+
+		void WriteCleanupStamp(const std::filesystem::path& stampPath, const std::vector<std::string>& details)
+		{
+			if (stampPath.empty())
+			{
+				return;
+			}
+
+			std::error_code ec;
+			std::filesystem::create_directories(stampPath.parent_path(), ec);
+			std::ofstream stamp(stampPath, std::ios::trunc);
+			if (stamp.is_open())
+			{
+				stamp << "cleanup complete\n";
+
+				for (const auto& detail : details)
+				{
+					stamp << detail << '\n';
+				}
+			}
+		}
+	}
+
 	class CleanupProgressDialog
 	{
 	public:
@@ -222,258 +258,236 @@ namespace Components
 	{
 		static std::once_flag once;
 		std::call_once(once, []()
+		{
+			std::vector<std::filesystem::path> roots;
+			if (const auto basePath = Utils::GetBaseFilesLocation(); !basePath.empty())
 			{
-				std::vector<std::filesystem::path> roots;
-				if (const auto basePath = Utils::GetBaseFilesLocation(); !basePath.empty())
-				{
-					roots.push_back(std::filesystem::path(basePath));
-				}
+				roots.push_back(std::filesystem::path(basePath));
+			}
 
-				try
+			try
+			{
+				auto curPath = std::filesystem::current_path();
+				if (roots.empty() || !std::filesystem::equivalent(roots.front(), curPath))
 				{
-					auto curPath = std::filesystem::current_path();
-					if (roots.empty() || !std::filesystem::equivalent(roots.front(), curPath))
-					{
-						roots.push_back(curPath);
-					}
+					roots.push_back(curPath);
 				}
-				catch (const std::exception&)
-				{
-				}
+			}
+			catch (const std::exception&)
+			{
+			}
 
+			const auto cleanupStampPath = GetCleanupStampPath(roots);
+			std::error_code stampEc;
+			if (!cleanupStampPath.empty() && std::filesystem::exists(cleanupStampPath, stampEc))
+			{
+				return;
+			}
+
+			struct CleanupTask
+			{
+				std::filesystem::path source;
+				std::filesystem::path destination;
+				bool move = false;
+			};
+
+			std::vector<CleanupTask> tasks;
+			std::unordered_set<std::wstring> seenTasks;
+
+			auto addDelete = [&](const std::filesystem::path& path)
+			{
 				std::error_code ec;
-				struct MigrationItem { std::wstring srcPath; std::wstring destPath; };
-				std::vector<MigrationItem> migrationFiles;
-				std::vector<std::filesystem::path> allDiscoveredFiles;
-				std::unordered_set<std::wstring> structuralDeleteSet;
-				std::vector<std::wstring> rawDirsToClean;
-				std::wstring globalUserrawScript;
-
-				if (const auto basePath = Utils::GetBaseFilesLocation(); !basePath.empty())
-				{
-					globalUserrawScript = (std::filesystem::path(basePath) / L"userraw" / L"scriptdata").wstring();
-				}
-
-				const auto shouldDelete = [&](const std::filesystem::path& path, const std::filesystem::path& root) -> bool
-					{
-						const auto relative = path.lexically_relative(root).generic_string();
-						std::string relativeLower = relative;
-						std::transform(relativeLower.begin(), relativeLower.end(), relativeLower.begin(),
-							[](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-						const auto filename = path.filename().string();
-						std::string filenameLower = filename;
-						std::transform(filenameLower.begin(), filenameLower.end(), filenameLower.begin(),
-							[](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-
-						if (relativeLower == "zw3.iwd"
-							|| relativeLower == "iw4x/zw3.iwd"
-							|| relativeLower == "main/zw3.iwd"
-							|| relativeLower == "userraw/zw3.iwd"
-							|| relativeLower == "zone/patch/patch_mp.ff"
-							|| relativeLower == "zone/english/zw3_common.ff")
-						{
-							return true;
-						}
-
-						if (relativeLower == "zw3/zw3.iwd")
-						{
-							return true;
-						}
-
-						if (relativeLower.size() >= 4 && relativeLower.rfind("zw3/", 0) == 0)
-						{
-							return false;
-						}
-
-						if (relativeLower == "zone/patch_mp.ff")
-						{
-							return true;
-						}
-
-						if (path.extension() == ".iwd"
-							&& filenameLower.rfind("mp_", 0) == 0
-							&& path.parent_path().filename() == "main")
-						{
-							return true;
-						}
-
-						return false;
-					};
-
-				for (const auto& root : roots)
-				{
-					std::wstring userrawScript = (root / L"userraw" / L"scriptdata").wstring();
-					std::wstring destScript = (root / L"zw3" / L"core" / L"scriptdata").wstring();
-
-					std::error_code internalEc;
-					if (!std::filesystem::exists(root, internalEc))
-					{
-						continue;
-					}
-
-					for (const auto& entry : std::filesystem::recursive_directory_iterator(root, internalEc))
-					{
-						if (internalEc)
-						{
-							break;
-						}
-
-						const auto& path = entry.path();
-						const auto relative = path.lexically_relative(root).generic_string();
-						std::string relativeLower = relative;
-						std::transform(relativeLower.begin(), relativeLower.end(), relativeLower.begin(),
-							[](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-
-						if (relativeLower.rfind("userraw/scriptdata", 0) == 0 || relativeLower.rfind("userraw\\scriptdata", 0) == 0)
-						{
-							std::error_code fileCheckEc;
-							if (std::filesystem::is_regular_file(path, fileCheckEc))
-							{
-								std::string filename = path.filename().string();
-								std::string filenameLower = filename;
-								std::transform(filenameLower.begin(), filenameLower.end(), filenameLower.begin(),
-									[](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-
-								if (filenameLower.rfind("autosave", 0) == 0 ||
-									filenameLower.rfind("rank_", 0) == 0 ||
-									filenameLower.rfind("easteregg", 0) == 0)
-								{
-									std::wstring fileWStr = path.wstring();
-									std::wstring relPath = fileWStr.substr(userrawScript.length());
-									migrationFiles.push_back({ fileWStr, destScript + relPath });
-								}
-							}
-							continue;
-						}
-
-						std::error_code fileCheckEc;
-						if (!std::filesystem::is_regular_file(path, fileCheckEc))
-						{
-							continue;
-						}
-
-						allDiscoveredFiles.push_back(path);
-						if (shouldDelete(path, root))
-						{
-							structuralDeleteSet.insert(path.wstring());
-						}
-					}
-				}
-
-				if (migrationFiles.empty() && structuralDeleteSet.empty())
+				if (!std::filesystem::is_regular_file(path, ec))
 				{
 					return;
 				}
 
-				int totalTasks = static_cast<int>(allDiscoveredFiles.size() + migrationFiles.size());
-				CleanupProgressDialog progress(totalTasks);
-
-				int deletedCount = 0;
-				int skippedCount = 0;
-				int movedCount = 0;
-
-				if (!migrationFiles.empty())
+				if (seenTasks.insert(path.wstring()).second)
 				{
-					for (const auto& fileItem : migrationFiles)
+					tasks.push_back({ path, {}, false });
+				}
+			};
+
+			auto addMove = [&](const std::filesystem::path& source, const std::filesystem::path& destination)
+			{
+				std::error_code ec;
+				if (!std::filesystem::is_regular_file(source, ec))
+				{
+					return;
+				}
+
+				if (seenTasks.insert(source.wstring()).second)
+				{
+					tasks.push_back({ source, destination, true });
+				}
+			};
+
+			const std::filesystem::path legacyFiles[] =
+			{
+				L"zw3.iwd",
+				L"iw4x/zw3.iwd",
+				L"main/zw3.iwd",
+				L"userraw/zw3.iwd",
+				L"zone/patch/patch_mp.ff",
+				L"zone/english/zw3_common.ff",
+				L"zw3/zw3.iwd",
+				L"zone/patch_mp.ff",
+			};
+
+			for (const auto& root : roots)
+			{
+				std::error_code ec;
+				if (!std::filesystem::exists(root, ec))
+				{
+					continue;
+				}
+
+				for (const auto& relative : legacyFiles)
+				{
+					addDelete(root / relative);
+				}
+
+				const auto mainDir = root / L"main";
+				if (std::filesystem::is_directory(mainDir, ec))
+				{
+					for (const auto& entry : std::filesystem::directory_iterator(mainDir, ec))
 					{
-						progress.Update(fileItem.srcPath);
-
-						size_t pos = fileItem.destPath.find_last_of(L"\\/");
-						if (pos != std::wstring::npos)
+						if (ec)
 						{
-							std::wstring targetDir = fileItem.destPath.substr(0, pos);
-							std::filesystem::create_directories(targetDir, ec);
+							break;
 						}
 
-						SetFileAttributesW(fileItem.srcPath.c_str(), FILE_ATTRIBUTE_NORMAL);
-						SetFileAttributesW(fileItem.destPath.c_str(), FILE_ATTRIBUTE_NORMAL);
+						const auto path = entry.path();
+						std::string filename = path.filename().string();
+						std::transform(filename.begin(), filename.end(), filename.begin(), [](unsigned char ch)
+						{
+							return static_cast<char>(std::tolower(ch));
+						});
 
-						if (CopyFileW(fileItem.srcPath.c_str(), fileItem.destPath.c_str(), FALSE))
+						if (path.extension() == ".iwd" && filename.rfind("mp_", 0) == 0)
 						{
-							DeleteFileW(fileItem.srcPath.c_str());
-							++movedCount;
-						}
-						else
-						{
-							if (MoveFileExW(fileItem.srcPath.c_str(), fileItem.destPath.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED))
-							{
-								++movedCount;
-							}
+							addDelete(path);
 						}
 					}
 				}
 
-				for (const auto& path : allDiscoveredFiles)
+				const auto userrawScript = root / L"userraw" / L"scriptdata";
+				const auto destScript = root / L"zw3" / L"core" / L"scriptdata";
+				if (std::filesystem::is_directory(userrawScript, ec))
 				{
-					const auto widePath = path.wstring();
-					progress.Update(widePath);
-
-					if (structuralDeleteSet.find(widePath) == structuralDeleteSet.end())
+					for (const auto& entry : std::filesystem::recursive_directory_iterator(userrawScript, ec))
 					{
-						++skippedCount;
+						if (ec)
+						{
+							break;
+						}
+
+						const auto path = entry.path();
+						if (!std::filesystem::is_regular_file(path, ec))
+						{
+							continue;
+						}
+
+						std::string filename = path.filename().string();
+						std::transform(filename.begin(), filename.end(), filename.begin(), [](unsigned char ch)
+						{
+							return static_cast<char>(std::tolower(ch));
+						});
+
+						if (filename.rfind("autosave", 0) == 0 || filename.rfind("rank_", 0) == 0 || filename.rfind("easteregg", 0) == 0)
+						{
+							addMove(path, destScript / path.lexically_relative(userrawScript));
+						}
+					}
+				}
+			}
+
+			if (tasks.empty())
+			{
+				WriteCleanupStamp(cleanupStampPath, {"no files to clear"});
+				return;
+			}
+
+			CleanupProgressDialog progress(static_cast<int>(tasks.size()));
+			int movedCount = 0;
+			int deletedCount = 0;
+			int skippedCount = 0;
+			std::vector<std::string> processedFiles;
+
+			for (const auto& task : tasks)
+			{
+				progress.Update(task.source.wstring());
+				std::error_code ec;
+				SetFileAttributesW(task.source.wstring().c_str(), FILE_ATTRIBUTE_NORMAL);
+
+				if (task.move)
+				{
+					std::filesystem::create_directories(task.destination.parent_path(), ec);
+					SetFileAttributesW(task.destination.wstring().c_str(), FILE_ATTRIBUTE_NORMAL);
+					if (MoveFileExW(task.source.wstring().c_str(), task.destination.wstring().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED))
+					{
+						processedFiles.emplace_back(std::format("moved: {} -> {}", task.source.string(), task.destination.string()));
+						++movedCount;
 						continue;
 					}
-
-					ec.clear();
-					if (!std::filesystem::exists(path, ec))
-					{
-						++skippedCount;
-						continue;
-					}
-
-					SetFileAttributesW(widePath.c_str(), FILE_ATTRIBUTE_NORMAL);
-
-					if (DeleteFileW(widePath.c_str()) != 0)
-					{
-						++deletedCount;
-						continue;
-					}
-
-					const auto winError = GetLastError();
-					if (winError == ERROR_FILE_NOT_FOUND)
-					{
-						++skippedCount;
-						continue;
-					}
-
-					if (winError == ERROR_SHARING_VIOLATION || winError == ERROR_ACCESS_DENIED)
-					{
-						progress.Close();
-						MessageBoxA(nullptr,
-							Utils::String::Format("File is in use and cannot be removed:\n{}\n\nPlease close any processes that are using this file and restart the game.",
-								path.string().c_str()),
-							"Error",
-							MB_OK | MB_ICONERROR);
-						std::exit(EXIT_FAILURE);
-					}
-
-					ec.clear();
-					const auto removed = std::filesystem::remove(path, ec);
-					if (!removed || ec)
-					{
-						progress.Close();
-						MessageBoxA(nullptr,
-							Utils::String::Format("Failed to remove file:\n{}\n\n{}",
-								path.string().c_str(),
-								ec ? ec.message().c_str() : "unknown"),
-							"Error",
-							MB_OK | MB_ICONERROR);
-						std::exit(EXIT_FAILURE);
-					}
-
+				}
+				else if (DeleteFileW(task.source.wstring().c_str()) != 0)
+				{
+					processedFiles.emplace_back(std::format("deleted: {}", task.source.string()));
 					++deletedCount;
+					continue;
 				}
 
-				progress.Close();
-				MessageBoxA(nullptr,
-					Utils::String::Format("Cleanup completed successfully.\n\nFiles checked: {}\nMoved: {}\nDeleted: {}\nSkipped: {}",
-						static_cast<int>(allDiscoveredFiles.size() + migrationFiles.size()),
-						movedCount,
-						deletedCount,
-						skippedCount),
-					"Done!",
-					MB_OK | MB_ICONINFORMATION);
-			});
+				const auto winError = GetLastError();
+				if (winError == ERROR_FILE_NOT_FOUND)
+				{
+					processedFiles.emplace_back(std::format("skipped (not found): {}", task.source.string()));
+					++skippedCount;
+					continue;
+				}
+
+				if (winError == ERROR_SHARING_VIOLATION || winError == ERROR_ACCESS_DENIED)
+				{
+					progress.Close();
+					MessageBoxA(nullptr,
+						Utils::String::Format("File is in use and cannot be updated:\n{}\n\nPlease close any processes that are using this file and restart the game.",
+							task.source.string().c_str()),
+						"Error",
+						MB_OK | MB_ICONERROR);
+					std::exit(EXIT_FAILURE);
+				}
+
+				if (!task.move && std::filesystem::remove(task.source, ec))
+				{
+					processedFiles.emplace_back(std::format("deleted: {}", task.source.string()));
+					++deletedCount;
+					continue;
+				}
+
+				processedFiles.emplace_back(task.move
+					? std::format("skipped: {} -> {}", task.source.string(), task.destination.string())
+					: std::format("skipped: {}", task.source.string()));
+				++skippedCount;
+			}
+
+			progress.Close();
+			std::vector<std::string> stampDetails;
+			stampDetails.emplace_back(std::format("files checked: {}", tasks.size()));
+			stampDetails.emplace_back(std::format("moved: {}", movedCount));
+			stampDetails.emplace_back(std::format("deleted: {}", deletedCount));
+			stampDetails.emplace_back(std::format("skipped: {}", skippedCount));
+			stampDetails.emplace_back("processed files:");
+			stampDetails.insert(stampDetails.end(), processedFiles.begin(), processedFiles.end());
+			WriteCleanupStamp(cleanupStampPath, stampDetails);
+			MessageBoxA(nullptr,
+				Utils::String::Format("Cleanup completed successfully.\n\nFiles checked: {}\nMoved: {}\nDeleted: {}\nSkipped: {}",
+					static_cast<int>(tasks.size()),
+					movedCount,
+					deletedCount,
+					skippedCount),
+				"Done!",
+				MB_OK | MB_ICONINFORMATION);
+		});
 	}
 
 	void FileSystem::File::read(Game::FsThread thread)
@@ -994,6 +1008,11 @@ namespace Components
 		Utils::Hook::Set<std::uint32_t>(0x64AF78, NEW_MAX_FILES_LISTED);
 		Utils::Hook::Set<std::uint32_t>(0x64B04F, NEW_MAX_FILES_LISTED);
 		Utils::Hook::Set<std::uint32_t>(0x45A8CE, NEW_MAX_FILES_LISTED);
+
+		Scheduler::OnGameInitialized([]
+		{
+			CleanupZw3Files();
+		}, Scheduler::Pipeline::ASYNC, 5s);
 
 		// Sys_ListFiles
 		Utils::Hook(0x45A806, Hunk_UserCreate_Stub, HOOK_CALL).install()->quick();

--- a/src/Components/Modules/Menus.cpp
+++ b/src/Components/Modules/Menus.cpp
@@ -2,6 +2,7 @@
 #include "Materials.hpp"
 #include "Party.hpp"
 #include "Events.hpp"
+#include "Renderer.hpp"
 #include <Utils/WebIO.hpp>
 #include <filesystem>
 // Ensure you have includes for AssetHandler, if it's a separate component.
@@ -1424,6 +1425,26 @@ namespace Components
 		// However, it's safer to ensure these arrays are valid.
 		if (!Menus::SupportingData->uifunctions.functions) {
 			InitializeSupportingData(); // Re-allocate the top-level arrays if they were freed
+		}
+
+		if (Renderer::ConsumeVidRestartUiReload() && !MenusFromDisk.empty())
+		{
+			// UI_Init runs during vid_restart. Re-parsing every loose menu here is
+			// slow, but dropping the menus means the restarted UI is incomplete.
+			// Keep the parsed disk menus and only reattach them to the fresh UI
+			// context. Clear old override bookkeeping first because it points at
+			// menus from the pre-restart UI context.
+			OverridenMenus.clear();
+			UpdateSupportingDataContents();
+
+			for (const auto& entry : MenusFromDisk)
+			{
+				AfterLoadedMenuFromDisk(entry.second);
+			}
+
+			CheckMenus();
+			DebugPrint("Reattached {} cached disk menus for vid_restart", MenusFromDisk.size());
+			return;
 		}
 
 		// Now, proceed with reloading all menus.

--- a/src/Components/Modules/QuickPatch.cpp
+++ b/src/Components/Modules/QuickPatch.cpp
@@ -775,7 +775,12 @@ namespace Components
 		Utils::Hook::Nop(0x4EBF1A, 5);
 #endif
 
-		if (Flags::HasFlag("nointro"))
+		// Starting the ZW3 cinematic here keeps the client in CA_LOGO before the
+		// menu can be used and also delays the real game window on some systems.
+		// Make the fast path the default; -intro is available for anyone who wants
+		// to force the branding cinematic back on. Keep -nointro accepted for
+		// backwards compatibility.
+		if (!Flags::HasFlag("intro") || Flags::HasFlag("nointro"))
 		{
 			Utils::Hook::Set<BYTE>(0x60BECF, 0xEB);
 		}

--- a/src/Components/Modules/Renderer.cpp
+++ b/src/Components/Modules/Renderer.cpp
@@ -9,6 +9,9 @@ namespace Components
 	Utils::Signal<Renderer::Callback> Renderer::EndRecoverDeviceSignal;
 	Utils::Signal<Renderer::Callback> Renderer::BeginRecoverDeviceSignal;
 
+	bool Renderer::VidRestarting = false;
+	bool Renderer::VidRestartUiReloadPending = false;
+
 	Dvar::Var Renderer::r_drawTriggers;
 	Dvar::Var Renderer::r_drawSceneModelCollisions;
 	Dvar::Var Renderer::r_drawModelBoundingBoxes;
@@ -101,14 +104,29 @@ namespace Components
 		return reinterpret_cast<LPPOINT>(0x66E1C68)->y;
 	}
 
+	bool Renderer::IsVidRestarting()
+	{
+		return Renderer::VidRestarting;
+	}
+
+	bool Renderer::ConsumeVidRestartUiReload()
+	{
+		const auto pending = Renderer::VidRestartUiReloadPending;
+		Renderer::VidRestartUiReloadPending = false;
+		return pending;
+	}
+
 	void Renderer::PreVidRestart()
 	{
+		Renderer::VidRestarting = true;
+		Renderer::VidRestartUiReloadPending = true;
 		Renderer::BeginRecoverDeviceSignal();
 	}
 
 	void Renderer::PostVidRestart()
 	{
 		Renderer::EndRecoverDeviceSignal();
+		Renderer::VidRestarting = false;
 	}
 
 	__declspec(naked) void Renderer::PostVidRestartStub()

--- a/src/Components/Modules/Renderer.hpp
+++ b/src/Components/Modules/Renderer.hpp
@@ -20,6 +20,9 @@ namespace Components
 		static void OnDeviceRecoveryEnd(Utils::Slot<Renderer::Callback> callback);
 		static void OnDeviceRecoveryBegin(Utils::Slot<Renderer::Callback> callback);
 
+		static bool IsVidRestarting();
+		static bool ConsumeVidRestartUiReload();
+
 	private:
 		static void BackendFrameStub();
 		static void BackendFrameHandler();
@@ -49,6 +52,9 @@ namespace Components
 
 		static Utils::Signal<Renderer::Callback> EndRecoverDeviceSignal;
 		static Utils::Signal<Renderer::Callback> BeginRecoverDeviceSignal;
+
+		static bool VidRestarting;
+		static bool VidRestartUiReloadPending;
 
 		static Utils::Signal<BackendCallback> BackendFrameSignal;
 		static Utils::Signal<BackendCallback> SingleBackendFrameSignal;

--- a/src/Components/Modules/Session.cpp
+++ b/src/Components/Modules/Session.cpp
@@ -135,13 +135,13 @@ namespace Components
 	Session::Session()
 	{
 #ifndef DISABLE_SESSION
-		Session::SignatureKey = Utils::Cryptography::ECC::GenerateKey(512);
 		//Scheduler::OnFrame(Session::RunFrame);
 
 		Session::Terminate = false;
 		Session::Thread = std::thread([]()
 		{
 			Com_InitThreadData();
+			Session::SignatureKey = Utils::Cryptography::ECC::GenerateKey(512);
 
 			while (!Session::Terminate)
 			{

--- a/src/DllMain.cpp
+++ b/src/DllMain.cpp
@@ -1,3 +1,255 @@
+namespace StartupSplash
+{
+	constexpr auto* WindowClassName = "ZW3StartupSplash";
+	constexpr UINT_PTR AnimationTimerId = 1;
+	constexpr LONG MinWindowWidth = 760;
+	constexpr LONG DefaultImageHeight = 380;
+	constexpr LONG FooterHeight = 118;
+
+	std::thread Thread;
+	std::atomic<HWND> Window = nullptr;
+	std::atomic_bool StopRequested = false;
+
+	HBITMAP SplashBitmap = nullptr;
+	HFONT StatusFont = nullptr;
+	HBRUSH BackgroundBrush = nullptr;
+	LONG ImageWidth = MinWindowWidth;
+	LONG ImageHeight = DefaultImageHeight;
+	LONG WindowWidth = MinWindowWidth;
+	LONG WindowHeight = DefaultImageHeight + FooterHeight;
+	int DotCount = 0;
+	int ProgressOffset = 0;
+	int AnimationTick = 0;
+
+	HBITMAP LoadSplashBitmap()
+	{
+		auto* bitmap = static_cast<HBITMAP>(LoadImageA(nullptr, "zw3/data/images/splash.bmp", IMAGE_BITMAP, 0, 0, LR_LOADFROMFILE));
+		if (!bitmap)
+		{
+			bitmap = static_cast<HBITMAP>(LoadImageA(nullptr, "iw4x/images/splash.bmp", IMAGE_BITMAP, 0, 0, LR_LOADFROMFILE));
+		}
+
+		return bitmap;
+	}
+
+	std::string GetStatusText()
+	{
+		std::string text = "Launching game, please wait";
+		text.append(DotCount, '.');
+		return text;
+	}
+
+	void Paint(HWND hwnd)
+	{
+		PAINTSTRUCT ps{};
+		const auto dc = BeginPaint(hwnd, &ps);
+		if (!dc)
+		{
+			return;
+		}
+
+		RECT client{};
+		GetClientRect(hwnd, &client);
+
+		const auto bufferDc = CreateCompatibleDC(dc);
+		const auto bufferBitmap = CreateCompatibleBitmap(dc, client.right - client.left, client.bottom - client.top);
+		const auto oldBufferBitmap = SelectObject(bufferDc, bufferBitmap);
+
+		FillRect(bufferDc, &client, BackgroundBrush);
+
+		if (SplashBitmap)
+		{
+			const auto imageDc = CreateCompatibleDC(bufferDc);
+			const auto oldBitmap = SelectObject(imageDc, SplashBitmap);
+			BitBlt(bufferDc, (WindowWidth - ImageWidth) / 2, 0, ImageWidth, ImageHeight, imageDc, 0, 0, SRCCOPY);
+			SelectObject(imageDc, oldBitmap);
+			DeleteDC(imageDc);
+		}
+
+		RECT footer{ 0, ImageHeight, WindowWidth, WindowHeight };
+		const auto footerBrush = CreateSolidBrush(RGB(12, 12, 14));
+		FillRect(bufferDc, &footer, footerBrush);
+		DeleteObject(footerBrush);
+
+		SetBkMode(bufferDc, TRANSPARENT);
+		SetTextColor(bufferDc, RGB(238, 238, 238));
+		const auto oldFont = SelectObject(bufferDc, StatusFont);
+
+		auto text = GetStatusText();
+		RECT textRect{ 0, ImageHeight + 24, WindowWidth, ImageHeight + 52 };
+		DrawTextA(bufferDc, text.data(), -1, &textRect, DT_CENTER | DT_SINGLELINE | DT_VCENTER);
+
+		SelectObject(bufferDc, oldFont);
+
+		const auto trackWidth = std::min<LONG>(WindowWidth - 128, 560);
+		const auto trackHeight = 10;
+		const auto trackX = (WindowWidth - trackWidth) / 2;
+		const auto trackY = ImageHeight + 72;
+		const auto chunkWidth = 150;
+		const auto chunkX = trackX + (ProgressOffset % (trackWidth + chunkWidth)) - chunkWidth;
+
+		const auto nullPen = static_cast<HPEN>(GetStockObject(NULL_PEN));
+		const auto oldPen = SelectObject(bufferDc, nullPen);
+
+		const auto trackBrush = CreateSolidBrush(RGB(42, 42, 46));
+		const auto oldBrush = SelectObject(bufferDc, trackBrush);
+		RoundRect(bufferDc, trackX, trackY, trackX + trackWidth, trackY + trackHeight, trackHeight, trackHeight);
+
+		HRGN clip = CreateRoundRectRgn(trackX, trackY, trackX + trackWidth, trackY + trackHeight, trackHeight, trackHeight);
+		SelectClipRgn(bufferDc, clip);
+
+		const auto chunkBrush = CreateSolidBrush(RGB(190, 32, 38));
+		SelectObject(bufferDc, chunkBrush);
+		RoundRect(bufferDc, chunkX, trackY, chunkX + chunkWidth, trackY + trackHeight, trackHeight, trackHeight);
+
+		SelectClipRgn(bufferDc, nullptr);
+		DeleteObject(clip);
+		SelectObject(bufferDc, oldBrush);
+		SelectObject(bufferDc, oldPen);
+		DeleteObject(chunkBrush);
+		DeleteObject(trackBrush);
+
+		BitBlt(dc, 0, 0, client.right - client.left, client.bottom - client.top, bufferDc, 0, 0, SRCCOPY);
+		SelectObject(bufferDc, oldBufferBitmap);
+		DeleteObject(bufferBitmap);
+		DeleteDC(bufferDc);
+
+		EndPaint(hwnd, &ps);
+	}
+
+	LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+	{
+		switch (message)
+		{
+		case WM_TIMER:
+			if (wParam == AnimationTimerId)
+			{
+				++AnimationTick;
+				if ((AnimationTick % 14) == 0)
+				{
+					DotCount = (DotCount + 1) % 4;
+				}
+
+				ProgressOffset = (ProgressOffset + 10) % (WindowWidth + 180);
+				InvalidateRect(hwnd, nullptr, FALSE);
+				return 0;
+			}
+			break;
+
+		case WM_ERASEBKGND:
+			return 1;
+
+		case WM_PAINT:
+			Paint(hwnd);
+			return 0;
+
+		case WM_CLOSE:
+			DestroyWindow(hwnd);
+			return 0;
+
+		case WM_DESTROY:
+			KillTimer(hwnd, AnimationTimerId);
+			PostQuitMessage(0);
+			return 0;
+		}
+
+		return DefWindowProcA(hwnd, message, wParam, lParam);
+	}
+
+	void ThreadProc()
+	{
+		const auto instance = GetModuleHandleA(nullptr);
+		BackgroundBrush = CreateSolidBrush(RGB(10, 10, 12));
+
+		WNDCLASSA wc{};
+		wc.lpfnWndProc = WindowProc;
+		wc.hInstance = instance;
+		wc.hCursor = LoadCursor(nullptr, IDC_ARROW);
+		wc.hbrBackground = BackgroundBrush;
+		wc.lpszClassName = WindowClassName;
+		RegisterClassA(&wc);
+
+		SplashBitmap = LoadSplashBitmap();
+		BITMAP info{};
+		if (SplashBitmap)
+		{
+			GetObjectA(SplashBitmap, sizeof(info), &info);
+		}
+
+		ImageWidth = info.bmWidth > 0 ? info.bmWidth : MinWindowWidth;
+		ImageHeight = info.bmHeight > 0 ? info.bmHeight : DefaultImageHeight;
+		WindowWidth = std::max(ImageWidth, MinWindowWidth);
+		WindowHeight = ImageHeight + FooterHeight;
+
+		const auto x = (GetSystemMetrics(SM_CXSCREEN) - WindowWidth) / 2;
+		const auto y = (GetSystemMetrics(SM_CYSCREEN) - WindowHeight) / 2;
+
+		auto* hwnd = CreateWindowExA(WS_EX_TOOLWINDOW | WS_EX_TOPMOST, WindowClassName, "Call of Duty: Zombie Warfare 3",
+			WS_POPUP, x, y, WindowWidth, WindowHeight, nullptr, nullptr, instance, nullptr);
+
+		if (!hwnd)
+		{
+			if (SplashBitmap) DeleteObject(SplashBitmap);
+			if (BackgroundBrush) DeleteObject(BackgroundBrush);
+			return;
+		}
+
+		StatusFont = CreateFontA(20, 0, 0, 0, FW_SEMIBOLD, FALSE, FALSE, FALSE, DEFAULT_CHARSET,
+			OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_SWISS, "Segoe UI");
+
+		Window.store(hwnd);
+		ShowWindow(hwnd, SW_SHOWNORMAL);
+		UpdateWindow(hwnd);
+		SetTimer(hwnd, AnimationTimerId, 35, nullptr);
+
+		if (StopRequested.load())
+		{
+			DestroyWindow(hwnd);
+		}
+
+		MSG msg{};
+		while (GetMessageA(&msg, nullptr, 0, 0) > 0)
+		{
+			TranslateMessage(&msg);
+			DispatchMessageA(&msg);
+		}
+
+		Window.store(nullptr);
+		if (StatusFont) DeleteObject(StatusFont);
+		if (SplashBitmap) DeleteObject(SplashBitmap);
+		if (BackgroundBrush) DeleteObject(BackgroundBrush);
+		StatusFont = nullptr;
+		SplashBitmap = nullptr;
+		BackgroundBrush = nullptr;
+	}
+
+	void Start()
+	{
+		if (std::strstr(GetCommandLineA(), "-dedicated") || std::strstr(GetCommandLineA(), "+set dedicated"))
+		{
+			return;
+		}
+
+		StopRequested.store(false);
+		Thread = std::thread(ThreadProc);
+	}
+
+	void Stop()
+	{
+		StopRequested.store(true);
+
+		if (const auto hwnd = Window.load())
+		{
+			PostMessageA(hwnd, WM_CLOSE, 0, 0);
+		}
+
+		if (Thread.joinable())
+		{
+			Thread.join();
+		}
+	}
+}
+
 namespace Main
 {
 	void Initialize()
@@ -5,16 +257,17 @@ namespace Main
 		std::srand(std::uint32_t(std::time(nullptr)) ^ ~(GetTickCount() * GetCurrentProcessId()));
 
 		Utils::SetEnvironment();
-
-		Components::FileSystem::CleanupZw3Files();
+		StartupSplash::Start();
 
 		Steam::Proxy::RunMod();
-		Utils::Cryptography::Initialize();
 		Components::Loader::Initialize();
+
+		StartupSplash::Stop();
 	}
 
 	void Uninitialize()
 	{
+		StartupSplash::Stop();
 		Components::Loader::Uninitialize();
 	}
 

--- a/src/Utils/Cryptography.cpp
+++ b/src/Utils/Cryptography.cpp
@@ -14,6 +14,10 @@ namespace Utils
 #pragma region Rand
 
 		prng_state Rand::State;
+		namespace
+		{
+			std::once_flag RandInitialized;
+		}
 
 		std::string Rand::GenerateChallenge()
 		{
@@ -29,6 +33,8 @@ namespace Utils
 
 		std::uint64_t Rand::GenerateLong()
 		{
+			Rand::Initialize();
+
 			std::uint64_t number = 0;
 			fortuna_read(reinterpret_cast<std::uint8_t*>(&number), sizeof(number), &Rand::State);
 			return number;
@@ -36,6 +42,8 @@ namespace Utils
 
 		std::uint32_t Rand::GenerateInt()
 		{
+			Rand::Initialize();
+
 			std::uint32_t number = 0;
 			fortuna_read(reinterpret_cast<std::uint8_t*>(&number), sizeof(number), &Rand::State);
 			return number;
@@ -43,9 +51,12 @@ namespace Utils
 
 		void Rand::Initialize()
 		{
-			ltc_mp = ltm_desc;
-			register_prng(&fortuna_desc);
-			rng_make_prng(128, find_prng("fortuna"), &Rand::State, nullptr);
+			std::call_once(RandInitialized, []
+			{
+				ltc_mp = ltm_desc;
+				register_prng(&fortuna_desc);
+				rng_make_prng(128, find_prng("fortuna"), &Rand::State, nullptr);
+			});
 		}
 
 #pragma endregion


### PR DESCRIPTION
### Motivation

- Reduce work done at DLL/loader attach and avoid doing file/system/steam work too early during startup.  
- Make the zw3 cleanup more robust, idempotent and user-friendly while avoiding repeated runs.  
- Improve UX with a lightweight startup splash and handle video device restarts cleanly so UI/menu reattachment can survive `vid_restart`.  
- Make RNG and session key generation safe to use from threads and delay expensive crypto ops until threads are initialized.

### Description

- Added a `StartupSplash` subsystem and start/stop calls in initialization to show a simple splash window while the mod initializes (`DllMain.cpp`).  
- Reworked `FileSystem::CleanupZw3Files()` to run once, produce a stamp file under `zw3/.zw3_cleanup_v2_complete`, and build a list of atomic tasks (move/delete) with a progress dialog and a detailed stamp report; the cleanup is now scheduled asynchronously on game initialization (`FileSystem.cpp`).  
- Removed immediate cleanup call from loader and schedule the cleanup via `Scheduler::OnGameInitialized` (deferred run) so startup is not blocked (`Loader.cpp`/`FileSystem.cpp`).  
- Deferred auth key loading and `Steam::SteamUser()->GetSteamID()` until the game is initialized using `Scheduler::OnGameInitialized` to avoid invoking Steam/API too early (`Auth.cpp`).  
- Split Discord initialization into `InitializeDiscord()` and schedule it on game init; skip Discord on dedicated/zone-builder runs and guard against double-initialize (`Discord.cpp`/`Discord.hpp`).  
- Add renderer vid-restart state flags and accessors (`IsVidRestarting`, `ConsumeVidRestartUiReload`) and set/clear them in `PreVidRestart`/`PostVidRestart` so other systems can react (used by `Menus.cpp`) (`Renderer.cpp`/`Renderer.hpp`).  
- Make menu reload path reuse cached parsed disk menus on `vid_restart` when `Renderer::ConsumeVidRestartUiReload()` is true, avoiding expensive reparsing and reattaching them to the new UI context (`Menus.cpp`).  
- Change intro/cinematic logic to make the fast path the default and preserve `-intro`/`-nointro` compatibility (`QuickPatch.cpp`).  
- Move ECC session key generation into the session worker thread so the cryptographic key is created after thread data is initialized (`Session.cpp`).  
- Harden RNG init by making `Rand::Initialize()` thread-safe via `std::call_once` and ensure `GenerateInt/Long` call `Initialize()` before use (`Cryptography.cpp`).

### Testing

- Automated build (`msbuild`/project build) completed successfully for the modified solution with no compile errors.  
- Ran automated smoke startup (DLL initialize → `Initialize()` → scheduled tasks) which started and stopped the `StartupSplash` and scheduled `CleanupZw3Files` without crashes.  
- Ran automated integration checks for `vid_restart` path that confirmed `ConsumeVidRestartUiReload()` allowed reattaching cached menus and did not regress UI initialization.  
- Existing automated unit/integration tests executed with no failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4feea3b9b08325b56efde1be539735)